### PR TITLE
Fix Log::write signature and add includes

### DIFF
--- a/log.cpp
+++ b/log.cpp
@@ -1,4 +1,10 @@
-Log::write(const wchar_t* message) {
+// log.cpp
+#include <windows.h>
+#include <fstream>
+#include <Shlwapi.h>
+#include <mutex>
+
+void Log::write(const wchar_t* message) {
     if (!g_debugEnabled) return; // Exit if debug is not enabled
 
     std::lock_guard<std::mutex> guard(g_mutex);

--- a/log.h
+++ b/log.h
@@ -1,5 +1,5 @@
 class Log {
     public:
 
-    void write(wchar_t*);
-}
+    void write(const wchar_t*);
+};


### PR DESCRIPTION
## Summary
- add missing includes in `log.cpp`
- update `Log::write` signature
- sync declaration in `log.h`

## Testing
- `g++ -std=c++17 -c *.cpp` *(fails: constants.h, windows.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68685f73e46883259ea8d43e264b9718