### PR TITLE
Use Configuration class in main executable

### DIFF
--- a/configuration.cpp
+++ b/configuration.cpp
@@ -1,49 +1,41 @@
+#include "configuration.h"
 #include <windows.h>
 #include <Shlwapi.h>
 #include <constants.h>
-#include <map>
-#include <string>
-#include <sstream>
 #include <fstream>
 #include <algorithm>
 
-class Configuration {
-public:
-    // Map to store settings (key:wstring, value:wstring)
-    std::map<std::wstring, std::wstring> settings;
+extern HINSTANCE g_hInst; // Provided by the executable
 
-    void load() {
-        wchar_t configPath[MAX_PATH];
-        GetModuleFileNameW(g_hInst, configPath, MAX_PATH);
-        PathRemoveFileSpecW(configPath);
-        PathCombineW(configPath, configPath, configFile.c_str());
+void Configuration::load() {
+    wchar_t configPath[MAX_PATH];
+    GetModuleFileNameW(g_hInst, configPath, MAX_PATH);
+    PathRemoveFileSpecW(configPath);
+    PathCombineW(configPath, configPath, configFile.c_str());
 
-        std::wifstream configFile(configPath);
-        if (configFile.is_open()) {
-            std::wstring line;
-            while (std::getline(configFile, line)) {
-                // Trim leading and trailing spaces
-                size_t start = line.find_first_not_of(L" \t\r\n");
-                size_t end = line.find_last_not_of(L" \t\r\n");
-                if (start == std::wstring::npos) {
-                    continue; // skip empty line
-                }
-                line = line.substr(start, end - start + 1);
-                if (line.empty()) continue;
-
-                // Split on '=' character
-                size_t eqPos = line.find(L'=');
-                if (eqPos != std::wstring::npos) {
-                    std::wstring key = line.substr(0, eqPos);
-                    std::wstring value = line.substr(eqPos + 1);
-
-                    // Convert key to lowercase
-                    std::transform(key.begin(), key.end(), key.begin(), [](wchar_t c) { return std::towlower(c); });
-
-                    settings[key] = value;
-                }
-            }
-            configFile.close();
-        }
+    std::wifstream file(configPath);
+    if (!file.is_open()) {
+        return;
     }
-};
+
+    std::wstring line;
+    while (std::getline(file, line)) {
+        size_t start = line.find_first_not_of(L" \t\r\n");
+        if (start == std::wstring::npos)
+            continue;
+        size_t end = line.find_last_not_of(L" \t\r\n");
+        line = line.substr(start, end - start + 1);
+        if (line.empty())
+            continue;
+
+        size_t eqPos = line.find(L'=');
+        if (eqPos == std::wstring::npos)
+            continue;
+
+        std::wstring key = line.substr(0, eqPos);
+        std::wstring value = line.substr(eqPos + 1);
+
+        std::transform(key.begin(), key.end(), key.begin(), [](wchar_t c) { return std::towlower(c); });
+        settings[key] = value;
+    }
+}

--- a/configuration.h
+++ b/configuration.h
@@ -1,7 +1,12 @@
 #pragma once
 
+#include <map>
+#include <string>
+
 class Configuration {
-    public:
+public:
+    // map containing lowercased keys from the config file
+    std::map<std::wstring, std::wstring> settings;
 
     void load();
 };


### PR DESCRIPTION
## Summary
- expose Configuration settings map
- implement Configuration::load in its own file
- remove custom LoadConfiguration() from kbdlayoutmon.cpp
- load config settings in WinMain and use them to set global options

## Testing
- `./scripts/sc-compile.bat >/tmp/compile.log && tail -n 20 /tmp/compile.log` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_686a810952e08325b16d25981fe59f21