### PR TITLE
Define CONFIG_FILE constant

### DIFF
--- a/configuration.cpp
+++ b/configuration.cpp
@@ -16,7 +16,7 @@ public:
         wchar_t configPath[MAX_PATH];
         GetModuleFileNameW(g_hInst, configPath, MAX_PATH);
         PathRemoveFileSpecW(configPath);
-        PathCombineW(configPath, configPath, configFile.c_str());
+        PathCombineW(configPath, configPath, CONFIG_FILE);
 
         std::wifstream configFile(configPath);
         if (configFile.is_open()) {

--- a/constants.h
+++ b/constants.h
@@ -1,4 +1,4 @@
 #pragma once
-#include <string>
 
-std::wstring configFile = L"kbdlayoutmon.config";
+// Name of the configuration file located next to the executable
+constexpr wchar_t CONFIG_FILE[] = L"kbdlayoutmon.config";

--- a/kbdlayoutmon.cpp
+++ b/kbdlayoutmon.cpp
@@ -7,6 +7,7 @@
 #include <sstream>
 #include <shellapi.h>
 #include "res-icon.h"  // Include the resource header
+#include "constants.h"
 
 #define TRAY_ICON_ID 1001
 #define WM_TRAYICON (WM_USER + 1)
@@ -71,7 +72,7 @@ void LoadConfiguration() {
     wchar_t configPath[MAX_PATH];
     GetModuleFileName(g_hInst, configPath, MAX_PATH);
     PathRemoveFileSpec(configPath);
-    PathCombine(configPath, configPath, L"kbdlayoutmon.config");
+    PathCombine(configPath, configPath, CONFIG_FILE);
 
     std::wifstream configFile(configPath);
     if (configFile.is_open()) {

--- a/kbdlayoutmonhook.cpp
+++ b/kbdlayoutmonhook.cpp
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <iomanip>
 #include <combaseapi.h>
+#include "constants.h"
 
 HINSTANCE g_hInst = NULL;
 HHOOK g_hHook = NULL;
@@ -48,7 +49,7 @@ void LoadConfiguration() {
     wchar_t configPath[MAX_PATH];
     GetModuleFileName(g_hInst, configPath, MAX_PATH);
     PathRemoveFileSpec(configPath);
-    PathCombine(configPath, configPath, L"kbdlayoutmon.config");
+    PathCombine(configPath, configPath, CONFIG_FILE);
 
     std::wifstream configFile(configPath);
     if (configFile.is_open()) {


### PR DESCRIPTION
## Summary
- add `CONFIG_FILE` constant in `constants.h`
- use `CONFIG_FILE` across the code base
- include `constants.h` where needed

## Testing
- `g++ -c kbdlayoutmon.cpp` *(fails: fatal error: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686a810b360483259051e87411d1bb38