### PR TITLE
Add root .gitignore for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Build artifacts
+/dist/
+*.obj
+*.exp
+*.lib
+*.dll
+*.exe
+*.res
+
+# Logs
+*.log


### PR DESCRIPTION
## Summary
- add a root `.gitignore` ignoring build outputs such as `dist/`, `.obj`, `.exp`, `.lib`, `.dll`, `.exe`, `.res`, and logs

## Testing
- `echo "no tests"`

------
https://chatgpt.com/codex/tasks/task_e_686d4d407cc88325823b9aa86a04e10f