### PR TITLE
Implement async logger

### DIFF
--- a/kbdlayoutmon.cpp
+++ b/kbdlayoutmon.cpp
@@ -8,6 +8,7 @@
 #include <shellapi.h>
 #include "res-icon.h"  // Include the resource header
 #include "configuration.h"
+#include "log.h"
 
 #define TRAY_ICON_ID 1001
 #define WM_TRAYICON (WM_USER + 1)
@@ -50,21 +51,7 @@ NOTIFYICONDATA nid;
 
 // Helper function to write to log file
 void WriteLog(const wchar_t* message) {
-    if (!g_debugEnabled) return; // Exit if debug is not enabled
-
-    std::lock_guard<std::mutex> guard(g_mutex);
-    wchar_t logPath[MAX_PATH];
-    GetModuleFileName(g_hInst, logPath, MAX_PATH);
-    PathRemoveFileSpec(logPath);
-    PathCombine(logPath, logPath, L"kbdlayoutmon.log");
-
-    std::wofstream logFile(logPath, std::ios::app);
-    if (logFile.is_open()) {
-        logFile << message << std::endl;
-        logFile.close();
-    } else {
-        OutputDebugString(L"Failed to open log file.");
-    }
+    g_log.write(message);
 }
 
 

--- a/kbdlayoutmonhook.cpp
+++ b/kbdlayoutmonhook.cpp
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <iomanip>
 #include <combaseapi.h>
+#include "log.h"
 
 HINSTANCE g_hInst = NULL;
 HHOOK g_hHook = NULL;
@@ -26,21 +27,7 @@ HANDLE g_hMutex = NULL;
 
 // Helper function to write to log file
 void WriteLog(const std::wstring& message) {
-    if (!g_debugEnabled) return; // Exit if debug is not enabled
-
-    std::lock_guard<std::mutex> guard(g_mutex);
-    wchar_t logPath[MAX_PATH];
-    GetModuleFileName(g_hInst, logPath, MAX_PATH);
-    PathRemoveFileSpec(logPath);
-    PathCombine(logPath, logPath, L"kbdlayoutmon.log");
-
-    std::wofstream logFile(logPath, std::ios::app);
-    if (logFile.is_open()) {
-        logFile << message << std::endl;
-        logFile.close();
-    } else {
-        OutputDebugString(L"Failed to open log file.");
-    }
+    g_log.write(message);
 }
 
 // Function to load configuration from a file

--- a/log.cpp
+++ b/log.cpp
@@ -1,23 +1,77 @@
-// log.cpp
+#include "log.h"
 #include <windows.h>
 #include <fstream>
 #include <Shlwapi.h>
-#include <mutex>
+#include <utility>
 
-void Log::write(const wchar_t* message) {
-    if (!g_debugEnabled) return; // Exit if debug is not enabled
+extern HINSTANCE g_hInst; // Provided by the executable or DLL
+extern bool g_debugEnabled;
 
-    std::lock_guard<std::mutex> guard(g_mutex);
-    wchar_t logPath[MAX_PATH];
-    GetModuleFileName(g_hInst, logPath, MAX_PATH);
-    PathRemoveFileSpec(logPath);
-    PathCombine(logPath, logPath, L"kbdlayoutmon.log");
-
-    std::wofstream logFile(logPath, std::ios::app);
-    if (logFile.is_open()) {
-        logFile << message << std::endl;
-        logFile.close();
+namespace {
+std::wstring GetLogPath() {
+    wchar_t logPath[MAX_PATH] = {0};
+    if (g_hInst) {
+        GetModuleFileName(g_hInst, logPath, MAX_PATH);
+        PathRemoveFileSpec(logPath);
+        PathCombine(logPath, logPath, L"kbdlayoutmon.log");
     } else {
-        OutputDebugString(L"Failed to open log file.");
+        lstrcpyW(logPath, L"kbdlayoutmon.log");
+    }
+    return logPath;
+}
+}
+
+Log g_log;
+
+Log::Log() {
+    m_running = true;
+    m_thread = std::thread(&Log::process, this);
+}
+
+Log::~Log() {
+    shutdown();
+}
+
+void Log::shutdown() {
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_running = false;
+    }
+    m_cv.notify_all();
+    if (m_thread.joinable())
+        m_thread.join();
+}
+
+void Log::write(const std::wstring& message) {
+    if (!g_debugEnabled)
+        return;
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_queue.push(message);
+    }
+    m_cv.notify_one();
+}
+
+void Log::process() {
+    for (;;) {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        m_cv.wait(lock, [this] { return !m_queue.empty() || !m_running; });
+        while (!m_queue.empty()) {
+            std::wstring msg = std::move(m_queue.front());
+            m_queue.pop();
+            lock.unlock();
+
+            std::wstring path = GetLogPath();
+            std::wofstream logFile(path, std::ios::app);
+            if (logFile.is_open()) {
+                logFile << msg << std::endl;
+            } else {
+                OutputDebugString(L"Failed to open log file.");
+            }
+            lock.lock();
+        }
+        if (!m_running && m_queue.empty())
+            break;
     }
 }
+

--- a/log.h
+++ b/log.h
@@ -1,6 +1,27 @@
 #pragma once
-class Log {
-    public:
 
-    void write(const wchar_t*);
+#include <string>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <queue>
+
+class Log {
+public:
+    Log();
+    ~Log();
+
+    void write(const std::wstring& message);
+    void shutdown();
+
+private:
+    void process();
+
+    std::thread m_thread;
+    std::mutex m_mutex;
+    std::condition_variable m_cv;
+    std::queue<std::wstring> m_queue;
+    bool m_running = false;
 };
+
+extern Log g_log;


### PR DESCRIPTION
## Summary
- add new asynchronous `Log` class
- use global `g_log` for executable and DLL logging
- include `log.h` where needed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d5aff9cb8832591ec67494ec9e7f0