### PR TITLE
Include configuration.cpp in build

### DIFF
--- a/scripts/sc-compile.bat
+++ b/scripts/sc-compile.bat
@@ -71,7 +71,7 @@ REM echo.
 REM echo [46mCompiling %OUTPUT_EXE%[0m
 REM echo.
 
-cl /nologo /EHsc /DUNICODE /D_UNICODE /W4 /MD %SOURCE_EXE% %OUTPUT_RES_ICO% %OUTPUT_RES_VER% /link /out:%OUTPUT_DIR%\%OUTPUT_EXE% shlwapi.lib user32.lib gdi32.lib ole32.lib advapi32.lib shell32.lib 2>&1 >nul
+cl /nologo /EHsc /DUNICODE /D_UNICODE /W4 /MD %SOURCE_EXE% configuration.cpp %OUTPUT_RES_ICO% %OUTPUT_RES_VER% /link /out:%OUTPUT_DIR%\%OUTPUT_EXE% shlwapi.lib user32.lib gdi32.lib ole32.lib advapi32.lib shell32.lib 2>&1 >nul
 if errorlevel 1 (
 	echo [91m[FAILED][0m Compile executable: %OUTPUT_EXE%
 ) else (


### PR DESCRIPTION
## Summary
- compile `configuration.cpp` into `kbdlayoutmon.exe`
- keep copying config and debug resources

## Testing
- `bash scripts/sc-compile.bat` *(fails: command not found for Windows tooling)*

------
https://chatgpt.com/codex/tasks/task_e_686d610d25a88325a986ee33cf8182fd