### PR TITLE
Add command line overrides

### DIFF
--- a/kbdlayoutmon.cpp
+++ b/kbdlayoutmon.cpp
@@ -375,6 +375,20 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         g_tempHotKeyTimeout = std::wcstoul(g_config.settings[L"temp_hotkey_timeout"].c_str(), nullptr, 10);
     }
 
+    // Parse command line options after the config file so they override
+    int argc = 0;
+    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+    if (argv) {
+        for (int i = 1; i < argc; ++i) {
+            if (wcscmp(argv[i], L"--no-tray") == 0) {
+                g_trayIconEnabled = false;
+            } else if (wcscmp(argv[i], L"--debug") == 0) {
+                g_debugEnabled = true;
+            }
+        }
+        LocalFree(argv);
+    }
+
     WriteLog(L"Executable started.");
 
     // Check if the app is set to launch at startup

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,15 @@ TEMP_HOTKEY_TIMEOUT=10000 # Milliseconds for temporary hotkeys to remain enabled
 LOG_PATH=path\to\logfile # Optional custom log file location
 ```
 
+## Command Line Options
+The executable also accepts a few optional flags which override settings in the
+configuration file:
+
+```
+--no-tray    Run without the system tray icon
+--debug      Enable debug logging
+```
+
 ## Build
 Visual Studio with C++ tools is required. Open a **Developer Command Prompt** for Visual Studio 2022 (or adjust the path in the script) and run:
 


### PR DESCRIPTION
## Summary
- allow `--no-tray` and `--debug` command line options
- document the new flags in the README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686d8e0165148325aa909184dea6d2e7