### PR TITLE
Add tray menu item to open log file

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,7 @@ Input Method Monitor is a small Windows utility that keeps your default input me
   - Launch the application at system startup.
   - Toggle Windows "Language" and "Layout" hotkeys.
   - Temporarily enable both hotkeys for a short period.
+  - Open the debug log file when logging is enabled.
   - Restart or exit the application.
 - Optional debug logging to `kbdlayoutmon.log`.
 


### PR DESCRIPTION
## Summary
- provide a new menu ID for opening the log file
- insert the new tray menu item
- handle the command via `ShellExecute`
- document the feature in README

## Testing
- `scripts/sc-compile.bat` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d95a2da0c8325aa75bacae57e571e