### PR TITLE
Add log and config sources to compile script

### DIFF
--- a/scripts/sc-compile.bat
+++ b/scripts/sc-compile.bat
@@ -71,7 +71,7 @@ REM echo.
 REM echo [46mCompiling %OUTPUT_EXE%[0m
 REM echo.
 
-cl /nologo /EHsc /DUNICODE /D_UNICODE /W4 /MD %SOURCE_EXE% configuration.cpp %OUTPUT_RES_ICO% %OUTPUT_RES_VER% /link /out:%OUTPUT_DIR%\%OUTPUT_EXE% shlwapi.lib user32.lib gdi32.lib ole32.lib advapi32.lib shell32.lib 2>&1 >nul
+cl /nologo /EHsc /DUNICODE /D_UNICODE /W4 /MD %SOURCE_EXE% log.cpp configuration.cpp %OUTPUT_RES_ICO% %OUTPUT_RES_VER% /link /out:%OUTPUT_DIR%\%OUTPUT_EXE% shlwapi.lib user32.lib gdi32.lib ole32.lib advapi32.lib shell32.lib 2>&1 >nul
 if errorlevel 1 (
 	echo [91m[FAILED][0m Compile executable: %OUTPUT_EXE%
 ) else (
@@ -82,7 +82,7 @@ REM Compile kbdlayoutmonhook.dll
 REM echo.
 REM echo [46mCompiling %OUTPUT_DLL%.[0m
 REM echo.
-cl /nologo /EHsc /DUNICODE /D_UNICODE /W4 /MD /LD %SOURCE_LIB% /link /out:%OUTPUT_DIR%\%OUTPUT_DLL% shlwapi.lib user32.lib gdi32.lib ole32.lib advapi32.lib 2>&1 >nul
+cl /nologo /EHsc /DUNICODE /D_UNICODE /W4 /MD /LD %SOURCE_LIB% log.cpp configuration.cpp /link /out:%OUTPUT_DIR%\%OUTPUT_DLL% shlwapi.lib user32.lib gdi32.lib ole32.lib advapi32.lib 2>&1 >nul
 if errorlevel 1 (
     echo [91m[FAILED][0m Compile dll, %OUTPUT_DLL%.
 ) else (


### PR DESCRIPTION
## Summary
- include log.cpp in executable and DLL compilation

## Testing
- `x86_64-w64-mingw32-g++ ... -o build/kbdlayoutmon.exe -lshlwapi -lgdi32 -luser32 -lole32 -ladvapi32 -lshell32` *(fails: no matching function for call to `std::basic_ofstream`)*
- `x86_64-w64-mingw32-g++ ... -shared kbdlayoutmonhook.cpp ...` *(fails: `IncrementRefCount` not declared)*


------
https://chatgpt.com/codex/tasks/task_e_686d95bad6a4832598c279f75b2d4d11