### PR TITLE
Add timestamp to log output

### DIFF
--- a/log.cpp
+++ b/log.cpp
@@ -70,7 +70,11 @@ void Log::process() {
             std::wstring path = GetLogPath();
             std::wofstream logFile(path, std::ios::app);
             if (logFile.is_open()) {
-                logFile << msg << std::endl;
+                SYSTEMTIME st{};
+                GetLocalTime(&st);
+                wchar_t ts[32] = {0};
+                swprintf(ts, 32, L"%04d-%02d-%02d %02d:%02d:%02d", st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);
+                logFile << ts << L" " << msg << std::endl;
             } else {
                 OutputDebugString(L"Failed to open log file.");
             }


### PR DESCRIPTION
## Summary
- add a formatted timestamp before each log message

## Testing
- `x86_64-w64-mingw32-g++ -std=c++17 -c log.cpp` *(fails: Shlwapi.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686d9fa7fc9083259989b2f5540710e6