### PR TITLE
Add script to compile and run app

### DIFF
--- a/scripts/sc-debug-full.bat
+++ b/scripts/sc-debug-full.bat
@@ -1,0 +1,23 @@
+@echo off
+setlocal
+
+REM Compile the project
+call "%~dp0sc-compile.bat"
+if errorlevel 1 (
+    echo [FAILED] Compilation failed. Exiting.
+    endlocal
+    exit /b 1
+)
+
+REM Launch the built executable
+pushd "%~dp0dist" >nul
+kbdlayoutmon.exe
+popd >nul
+
+REM Optional: tail the debug log
+set /p TAIL_LOG="Tail log file? (y/N): "
+if /I "%TAIL_LOG%"=="Y" (
+    call "%~dp0sc-taildebug.bat"
+)
+
+endlocal


### PR DESCRIPTION
## Summary
- add `sc-debug-full.bat` with steps to compile and run the application
- include optional prompt to tail the debug log

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686daa0db4648325864726b0677f537c