### PR TITLE
Add --version flag

### DIFF
--- a/kbdlayoutmon.cpp
+++ b/kbdlayoutmon.cpp
@@ -6,6 +6,7 @@
 #include <mutex>
 #include <sstream>
 #include <shellapi.h>
+#include <vector>
 #include "res-icon.h"  // Include the resource header
 #include "configuration.h"
 #include "log.h"
@@ -55,6 +56,35 @@ NOTIFYICONDATA nid;
 // Helper function to write to log file
 void WriteLog(const wchar_t* message) {
     g_log.write(message);
+}
+
+// Retrieve version information from the executable's version resource
+std::wstring GetVersionString() {
+    wchar_t path[MAX_PATH] = {0};
+    if (!GetModuleFileNameW(NULL, path, MAX_PATH))
+        return L"";
+
+    DWORD handle = 0;
+    DWORD size = GetFileVersionInfoSizeW(path, &handle);
+    if (size == 0)
+        return L"";
+
+    std::vector<BYTE> data(size);
+    if (!GetFileVersionInfoW(path, handle, size, data.data()))
+        return L"";
+
+    VS_FIXEDFILEINFO* info = nullptr;
+    UINT len = 0;
+    if (!VerQueryValueW(data.data(), L"\\", reinterpret_cast<LPVOID*>(&info), &len) || len == 0)
+        return L"";
+
+    wchar_t ver[64] = {0};
+    swprintf(ver, 64, L"%u.%u.%u.%u",
+             HIWORD(info->dwFileVersionMS),
+             LOWORD(info->dwFileVersionMS),
+             HIWORD(info->dwFileVersionLS),
+             LOWORD(info->dwFileVersionLS));
+    return ver;
 }
 
 
@@ -414,6 +444,24 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
                 g_trayIconEnabled = false;
             } else if (wcscmp(argv[i], L"--debug") == 0) {
                 g_debugEnabled = true;
+            } else if (wcscmp(argv[i], L"--version") == 0) {
+                std::wstring version = GetVersionString();
+                if (AttachConsole(ATTACH_PARENT_PROCESS)) {
+                    FILE* fp = _wfopen(L"CONOUT$", L"w");
+                    if (fp) {
+                        fwprintf(fp, L"%s\n", version.c_str());
+                        fclose(fp);
+                    }
+                    FreeConsole();
+                } else {
+                    MessageBox(NULL, version.c_str(), L"Input Method Monitor", MB_OK | MB_ICONINFORMATION);
+                }
+                LocalFree(argv);
+                if (g_hInstanceMutex) {
+                    ReleaseMutex(g_hInstanceMutex);
+                    CloseHandle(g_hInstanceMutex);
+                }
+                return 0;
             }
         }
         LocalFree(argv);

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,7 @@ configuration file:
 ```
 --no-tray    Run without the system tray icon
 --debug      Enable debug logging
+--version    Print the application version and exit
 ```
 
 ## Build

--- a/scripts/sc-compile.bat
+++ b/scripts/sc-compile.bat
@@ -71,7 +71,7 @@ REM echo.
 REM echo [46mCompiling %OUTPUT_EXE%[0m
 REM echo.
 
-cl /nologo /EHsc /DUNICODE /D_UNICODE /W4 /MD %SOURCE_EXE% log.cpp configuration.cpp %OUTPUT_RES_ICO% %OUTPUT_RES_VER% /link /out:%OUTPUT_DIR%\%OUTPUT_EXE% shlwapi.lib user32.lib gdi32.lib ole32.lib advapi32.lib shell32.lib 2>&1 >nul
+cl /nologo /EHsc /DUNICODE /D_UNICODE /W4 /MD %SOURCE_EXE% log.cpp configuration.cpp %OUTPUT_RES_ICO% %OUTPUT_RES_VER% /link /out:%OUTPUT_DIR%\%OUTPUT_EXE% shlwapi.lib user32.lib gdi32.lib ole32.lib advapi32.lib shell32.lib version.lib 2>&1 >nul
 if errorlevel 1 (
 	echo [91m[FAILED][0m Compile executable: %OUTPUT_EXE%
 ) else (


### PR DESCRIPTION
## Summary
- implement GetVersionString using Windows version APIs
- print version info when passing `--version` on the command line
- document the new flag in `readme.md`
- link against `version.lib` in the build script

## Testing
- `g++ --version | head -n 1`


------
https://chatgpt.com/codex/tasks/task_e_686e5ba59e448325839039a17dbaa5a7