### PR TITLE
Centralize logging

### DIFF
--- a/kbdlayoutmon.cpp
+++ b/kbdlayoutmon.cpp
@@ -53,7 +53,7 @@ NOTIFYICONDATA nid;
 
 
 // Helper function to write to log file
-void WriteLog(const wchar_t* message) {
+extern "C" __declspec(dllexport) void WriteLog(const wchar_t* message) {
     g_log.write(message);
 }
 

--- a/scripts/sc-compile.bat
+++ b/scripts/sc-compile.bat
@@ -82,7 +82,7 @@ REM Compile kbdlayoutmonhook.dll
 REM echo.
 REM echo [46mCompiling %OUTPUT_DLL%.[0m
 REM echo.
-cl /nologo /EHsc /DUNICODE /D_UNICODE /W4 /MD /LD %SOURCE_LIB% log.cpp configuration.cpp /link /out:%OUTPUT_DIR%\%OUTPUT_DLL% shlwapi.lib user32.lib gdi32.lib ole32.lib advapi32.lib 2>&1 >nul
+cl /nologo /EHsc /DUNICODE /D_UNICODE /W4 /MD /LD %SOURCE_LIB% /link /out:%OUTPUT_DIR%\%OUTPUT_DLL% shlwapi.lib user32.lib gdi32.lib ole32.lib advapi32.lib 2>&1 >nul
 if errorlevel 1 (
     echo [91m[FAILED][0m Compile dll, %OUTPUT_DLL%.
 ) else (


### PR DESCRIPTION
## Summary
- export `WriteLog` from the executable
- call exported log function from the DLL
- remove redundant logging code and configuration usage in DLL
- link DLL without the logging source

## Testing
- `bash scripts/sc-compile.bat` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e5b9192d88325a081b4e0cfc2b769