### PR TITLE
Add --help support

### DIFF
--- a/kbdlayoutmon.cpp
+++ b/kbdlayoutmon.cpp
@@ -87,6 +87,17 @@ std::wstring GetVersionString() {
     return ver;
 }
 
+// Return a short usage string describing supported options
+std::wstring GetUsageString() {
+    return
+        L"Usage: kbdlayoutmon [options]\n\n"
+        L"Options:\n"
+        L"  --no-tray    Run without the system tray icon\n"
+        L"  --debug      Enable debug logging\n"
+        L"  --version    Print the application version and exit\n"
+        L"  --help       Show this help message and exit";
+}
+
 
 
 // Helper function to check if app is set to launch at startup
@@ -455,6 +466,24 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
                     FreeConsole();
                 } else {
                     MessageBox(NULL, version.c_str(), L"Input Method Monitor", MB_OK | MB_ICONINFORMATION);
+                }
+                LocalFree(argv);
+                if (g_hInstanceMutex) {
+                    ReleaseMutex(g_hInstanceMutex);
+                    CloseHandle(g_hInstanceMutex);
+                }
+                return 0;
+            } else if (wcscmp(argv[i], L"--help") == 0) {
+                std::wstring usage = GetUsageString();
+                if (AttachConsole(ATTACH_PARENT_PROCESS)) {
+                    FILE* fp = _wfopen(L"CONOUT$", L"w");
+                    if (fp) {
+                        fwprintf(fp, L"%s\n", usage.c_str());
+                        fclose(fp);
+                    }
+                    FreeConsole();
+                } else {
+                    MessageBox(NULL, usage.c_str(), L"Input Method Monitor", MB_OK | MB_ICONINFORMATION);
                 }
                 LocalFree(argv);
                 if (g_hInstanceMutex) {

--- a/readme.md
+++ b/readme.md
@@ -25,12 +25,13 @@ LOG_PATH=path\to\logfile # Optional custom log file location
 
 ## Command Line Options
 The executable also accepts a few optional flags which override settings in the
-configuration file:
+configuration file. Use `--help` to display a summary at runtime:
 
 ```
 --no-tray    Run without the system tray icon
 --debug      Enable debug logging
 --version    Print the application version and exit
+--help       Show this help text
 ```
 
 ## Build


### PR DESCRIPTION
## Summary
- add `GetUsageString` helper and check for `--help` argument
- show usage information in a message box or console
- document the new flag in the README

## Testing
- `g++ -c -std=c++17 kbdlayoutmon.cpp -o /tmp/test.o` *(fails: windows.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ef63978948325a798531fccc08308