### PR TITLE
Add runtime debug toggle via tray

### DIFF
--- a/kbdlayoutmon.cpp
+++ b/kbdlayoutmon.cpp
@@ -27,6 +27,7 @@ void StopConfigWatcher();
 #define ID_TRAY_APP_NAME 1006
 #define ID_TRAY_RESTART 1007
 #define ID_TRAY_OPEN_LOG 1008
+#define ID_TRAY_TOGGLE_DEBUG 1009
 #define WM_UPDATE_TRAY_MENU (WM_USER + 2)
 
 HINSTANCE g_hInst = NULL;
@@ -428,12 +429,14 @@ void ShowTrayMenu(HWND hwnd) {
     InsertMenu(hMenu, 5, MF_BYPOSITION | MF_STRING, ID_TRAY_TEMP_ENABLE_HOTKEYS, L"Temporarily Enable HotKeys");
     // Add open log option
     InsertMenu(hMenu, 6, MF_BYPOSITION | MF_STRING, ID_TRAY_OPEN_LOG, L"Open Log File");
+    // Add debug toggle option with checkmark if enabled
+    InsertMenu(hMenu, 7, MF_BYPOSITION | MF_STRING | (g_debugEnabled ? MF_CHECKED : 0), ID_TRAY_TOGGLE_DEBUG, L"Debug Logging");
     // Add separator
-    InsertMenu(hMenu, 7, MF_BYPOSITION | MF_SEPARATOR, 0, NULL);
+    InsertMenu(hMenu, 8, MF_BYPOSITION | MF_SEPARATOR, 0, NULL);
     // Add restart option
-    InsertMenu(hMenu, 8, MF_BYPOSITION | MF_STRING, ID_TRAY_RESTART, L"Restart");
+    InsertMenu(hMenu, 9, MF_BYPOSITION | MF_STRING, ID_TRAY_RESTART, L"Restart");
     // Add exit option
-    InsertMenu(hMenu, 9, MF_BYPOSITION | MF_STRING, ID_TRAY_EXIT, L"Quit");
+    InsertMenu(hMenu, 10, MF_BYPOSITION | MF_STRING, ID_TRAY_EXIT, L"Quit");
 
     // Set the foreground window before calling TrackPopupMenu or the menu will not disappear when the user clicks outside of it
     SetForegroundWindow(hwnd);
@@ -488,6 +491,15 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
                     ShellExecute(NULL, L"open", logPath, NULL, NULL, SW_SHOWNORMAL);
                     break;
                 }
+                case ID_TRAY_TOGGLE_DEBUG:
+                    if (g_debugEnabled) {
+                        WriteLog(L"Debug logging disabled.");
+                        g_debugEnabled = false;
+                    } else {
+                        g_debugEnabled = true;
+                        WriteLog(L"Debug logging enabled.");
+                    }
+                    break;
                 case ID_TRAY_RESTART:
                     // Restart the application
                     ShellExecute(NULL, L"open", L"cmd.exe", L"/C taskkill /IM kbdlayoutmon.exe /F && start kbdlayoutmon.exe", NULL, SW_HIDE);

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ Input Method Monitor is a small Windows utility that keeps your default input me
   - Toggle Windows "Language" and "Layout" hotkeys.
   - Temporarily enable both hotkeys for a short period.
   - Open the debug log file when logging is enabled.
+  - Toggle debug logging on or off at runtime.
   - Restart or exit the application.
 - Optional debug logging to `kbdlayoutmon.log`.
 
@@ -24,6 +25,7 @@ LOG_PATH=path\to\logfile # Optional custom log file location
 ```
 
 Changes to `kbdlayoutmon.config` are picked up automatically while the program is running.
+Debug logging can also be toggled on or off at runtime from the tray icon menu.
 
 ## Command Line Options
 The executable also accepts a few optional flags which override settings in the


### PR DESCRIPTION
## Summary
- add new menu command `ID_TRAY_TOGGLE_DEBUG`
- show checkable "Debug Logging" item in tray menu
- handle toggling of debug logging in `WindowProc`
- document runtime debug toggle in readme

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ef902179c83259f504c13efb49314