### PR TITLE
Add basic Catch2 tests

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+g++ -std=c++17 -I/usr/include/catch2 tests/test_configuration.cpp -o tests/run_tests -lCatch2Main -lCatch2 && ./tests/run_tests

--- a/tests/config_parser.h
+++ b/tests/config_parser.h
@@ -1,0 +1,55 @@
+#pragma once
+#include <map>
+#include <string>
+#include <algorithm>
+#include <cwctype>
+#include <vector>
+
+inline std::map<std::wstring, std::wstring> parse_config_lines(const std::vector<std::wstring>& lines) {
+    std::map<std::wstring, std::wstring> settings;
+    for (std::wstring line : lines) {
+        size_t start = line.find_first_not_of(L" \t\r\n");
+        if (start == std::wstring::npos)
+            continue;
+        size_t end = line.find_last_not_of(L" \t\r\n");
+        line = line.substr(start, end - start + 1);
+        if (line.empty())
+            continue;
+
+        size_t eqPos = line.find(L'=');
+        if (eqPos == std::wstring::npos)
+            continue;
+
+        std::wstring key = line.substr(0, eqPos);
+        std::wstring value = line.substr(eqPos + 1);
+
+        auto trim = [](std::wstring &s) {
+            size_t start = s.find_first_not_of(L" \t\r\n");
+            size_t end = s.find_last_not_of(L" \t\r\n");
+            if (start == std::wstring::npos) {
+                s.clear();
+            } else {
+                s = s.substr(start, end - start + 1);
+            }
+        };
+
+        trim(key);
+        trim(value);
+
+        std::transform(key.begin(), key.end(), key.begin(), [](wchar_t c){
+            return std::towlower(c);
+        });
+
+        if (key == L"temp_hotkey_timeout") {
+            try {
+                int timeout = std::stoi(value);
+                settings[key] = std::to_wstring(timeout);
+            } catch (...) {
+                settings[key] = L"10000";
+            }
+        } else {
+            settings[key] = value;
+        }
+    }
+    return settings;
+}

--- a/tests/test_configuration.cpp
+++ b/tests/test_configuration.cpp
@@ -1,0 +1,43 @@
+#include <catch2/catch_test_macros.hpp>
+#include "config_parser.h"
+#include <string>
+#include <vector>
+
+TEST_CASE("Valid entries are parsed", "[config]") {
+    std::vector<std::wstring> lines = {
+        L"DEBUG=1",
+        L"TRAY_ICON=0",
+        L"Temp_Hotkey_TimeOut=5000",
+        L"LOG_PATH=C:/tmp/log.txt"
+    };
+    auto settings = parse_config_lines(lines);
+    REQUIRE(settings[L"debug"] == L"1");
+    REQUIRE(settings[L"tray_icon"] == L"0");
+    REQUIRE(settings[L"temp_hotkey_timeout"] == L"5000");
+    REQUIRE(settings[L"log_path"] == L"C:/tmp/log.txt");
+}
+
+TEST_CASE("Malformed lines are ignored", "[config]") {
+    std::vector<std::wstring> lines = {
+        L"JUSTKEY",
+        L"   ",
+        L"NOEQUALS HERE",
+        L""
+    };
+    auto settings = parse_config_lines(lines);
+    REQUIRE(settings.empty());
+}
+
+TEST_CASE("Whitespace handling", "[config]") {
+    std::vector<std::wstring> lines = {
+        L"  DEBUG = 1  ",
+        L"\tTRAY_ICON\t=\t1\t",
+        L"TEMP_HOTKEY_TIMEOUT = notanumber",
+        L"  \tLOG_PATH\t =  path/space  "
+    };
+    auto settings = parse_config_lines(lines);
+    REQUIRE(settings[L"debug"] == L"1");
+    REQUIRE(settings[L"tray_icon"] == L"1");
+    REQUIRE(settings[L"temp_hotkey_timeout"] == L"10000");
+    REQUIRE(settings[L"log_path"] == L"path/space");
+}


### PR DESCRIPTION
## Summary
- add Catch2 test harness under `tests/`
- parse configuration lines and test valid, malformed and whitespace variants
- provide `scripts/run_tests.sh` to compile and run tests

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686efc3289cc8325b8886476355b84a2