### PR TITLE
Centralize logging via named pipe

### DIFF
--- a/configuration.cpp
+++ b/configuration.cpp
@@ -1,6 +1,6 @@
 #include "configuration.h"
 #include <windows.h>
-#include <Shlwapi.h>
+#include <shlwapi.h>
 #include "constants.h"
 #include <fstream>
 #include <algorithm>

--- a/kbdlayoutmon.cpp
+++ b/kbdlayoutmon.cpp
@@ -2,7 +2,7 @@
 #include <windows.h>
 #include <string>
 #include <fstream>
-#include <Shlwapi.h>
+#include <shlwapi.h>
 #include <mutex>
 #include <sstream>
 #include <shellapi.h>

--- a/log.h
+++ b/log.h
@@ -17,8 +17,10 @@ public:
 
 private:
     void process();
+    void pipeListener();
 
     std::thread m_thread;
+    std::thread m_pipeThread;
     std::mutex m_mutex;
     std::condition_variable m_cv;
     std::queue<std::wstring> m_queue;


### PR DESCRIPTION
## Summary
- adjust include casing for cross-platform builds
- introduce pipe listener thread in `Log`
- use the pipe in `kbdlayoutmonhook` to forward log messages
- remove direct calls to executable logging function

## Testing
- `x86_64-w64-mingw32-g++ -std=c++17 -DUNICODE -D_UNICODE -c log.cpp`
- `x86_64-w64-mingw32-g++ -std=c++17 -DUNICODE -D_UNICODE -c kbdlayoutmon.cpp` *(fails: res-icon.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_686efc32fd048325a850649688617186