### PR TITLE
Use safe checks when reading config

### DIFF
--- a/kbdlayoutmon.cpp
+++ b/kbdlayoutmon.cpp
@@ -328,12 +328,13 @@ void RemoveTrayIcon() {
 
 // Apply configuration values to runtime settings
 void ApplyConfig(HWND hwnd) {
-    bool debug = g_config.settings[L"debug"] == L"1";
-    g_debugEnabled = debug;
+    auto it = g_config.settings.find(L"debug");
+    g_debugEnabled = (it != g_config.settings.end() && it->second == L"1");
 
     bool tray = true;
-    if (g_config.settings.count(L"tray_icon"))
-        tray = g_config.settings[L"tray_icon"] != L"0";
+    it = g_config.settings.find(L"tray_icon");
+    if (it != g_config.settings.end())
+        tray = it->second != L"0";
     if (tray != g_trayIconEnabled) {
         if (tray) {
             g_trayIconEnabled = true;
@@ -346,9 +347,10 @@ void ApplyConfig(HWND hwnd) {
         }
     }
 
-    if (g_config.settings.count(L"temp_hotkey_timeout")) {
+    it = g_config.settings.find(L"temp_hotkey_timeout");
+    if (it != g_config.settings.end()) {
         g_tempHotKeyTimeout =
-            std::wcstoul(g_config.settings[L"temp_hotkey_timeout"].c_str(), nullptr, 10);
+            std::wcstoul(it->second.c_str(), nullptr, 10);
     }
 }
 

--- a/kbdlayoutmonhook.cpp
+++ b/kbdlayoutmonhook.cpp
@@ -10,6 +10,9 @@
 #include <thread>
 #include <condition_variable>
 #include <queue>
+#include "configuration.h"
+
+bool g_debugEnabled = false;
 HINSTANCE g_hInst = NULL;
 HHOOK g_hHook = NULL;
 std::mutex g_mutex;
@@ -279,6 +282,10 @@ BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved) {
         case DLL_PROCESS_ATTACH:
             g_hInst = hinstDLL;
             g_hMutex = CreateMutex(NULL, FALSE, L"Global\\KbdHookMutex");
+            {
+                auto it = g_config.settings.find(L"debug");
+                g_debugEnabled = (it != g_config.settings.end() && it->second == L"1");
+            }
             break;
         case DLL_PROCESS_DETACH:
             if (g_hMutex)


### PR DESCRIPTION
## Summary
- use find() when checking debug option in `ApplyConfig`
- do the same for tray icon and timeout settings
- initialize debug flag when hook DLL loads

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686f012f82ec8325bca3a3e5940391c8