### PR TITLE
Add custom config path option

### DIFF
--- a/configuration.cpp
+++ b/configuration.cpp
@@ -10,16 +10,29 @@ extern HINSTANCE g_hInst; // Provided by the executable
 // Global configuration instance shared across modules
 Configuration g_config;
 
-void Configuration::load() {
-    wchar_t configPath[MAX_PATH];
-    GetModuleFileNameW(g_hInst, configPath, MAX_PATH);
-    PathRemoveFileSpecW(configPath);
-    PathCombineW(configPath, configPath, configFile.c_str());
+void Configuration::load(const std::wstring& path) {
+    std::wstring fullPath;
 
-    std::wifstream file(configPath);
+    if (!path.empty()) {
+        m_lastPath = path;
+        fullPath = path;
+    } else if (!m_lastPath.empty()) {
+        fullPath = m_lastPath;
+    } else {
+        wchar_t configPath[MAX_PATH];
+        GetModuleFileNameW(g_hInst, configPath, MAX_PATH);
+        PathRemoveFileSpecW(configPath);
+        PathCombineW(configPath, configPath, configFile.c_str());
+        fullPath = configPath;
+        m_lastPath = fullPath;
+    }
+
+    std::wifstream file(fullPath);
     if (!file.is_open()) {
         return;
     }
+
+    settings.clear();
 
     std::wstring line;
     while (std::getline(file, line)) {

--- a/configuration.h
+++ b/configuration.h
@@ -8,7 +8,13 @@ public:
     // map containing lowercased keys from the config file
     std::map<std::wstring, std::wstring> settings;
 
-    void load();
+    // Load configuration from the given path. If no path is provided,
+    // the previously loaded path is used. When no path has been loaded
+    // yet, the default configuration file next to the executable is used.
+    void load(const std::wstring& path = L"");
+
+private:
+    std::wstring m_lastPath; // remembers the path of the last loaded config
 };
 
 extern Configuration g_config; // Shared configuration instance

--- a/kbdlayoutmon.cpp
+++ b/kbdlayoutmon.cpp
@@ -102,6 +102,7 @@ std::wstring GetUsageString() {
     return
         L"Usage: kbdlayoutmon [options]\n\n"
         L"Options:\n"
+        L"  --config <path>  Load configuration from the specified file\n"
         L"  --no-tray    Run without the system tray icon\n"
         L"  --debug      Enable debug logging\n"
         L"  --version    Print the application version and exit\n"
@@ -533,16 +534,29 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         return 0;
     }
 
+    // Parse command line arguments early to check for a custom config file
+    int argc = 0;
+    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+    std::wstring customConfigPath;
+    if (argv) {
+        for (int i = 1; i < argc; ++i) {
+            if (wcscmp(argv[i], L"--config") == 0 && i + 1 < argc) {
+                customConfigPath = argv[i + 1];
+                break;
+            }
+        }
+    }
+
     // Load configuration before any logging occurs
-    g_config.load();
+    g_config.load(customConfigPath);
     ApplyConfig(NULL);
 
     // Parse command line options after the config file so they override
-    int argc = 0;
-    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
     if (argv) {
         for (int i = 1; i < argc; ++i) {
-            if (wcscmp(argv[i], L"--no-tray") == 0) {
+            if (wcscmp(argv[i], L"--config") == 0 && i + 1 < argc) {
+                ++i; // skip the path argument
+            } else if (wcscmp(argv[i], L"--no-tray") == 0) {
                 g_trayIconEnabled = false;
             } else if (wcscmp(argv[i], L"--debug") == 0) {
                 g_debugEnabled = true;

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,7 @@ The executable also accepts a few optional flags which override settings in the
 configuration file. Use `--help` to display a summary at runtime:
 
 ```
+--config <path>  Load configuration from the specified file
 --no-tray    Run without the system tray icon
 --debug      Enable debug logging
 --version    Print the application version and exit


### PR DESCRIPTION
## Summary
- add an optional parameter to `Configuration::load`
- read `--config <path>` before loading configuration
- show new option in usage output and README

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686f010eea248325b0249b02a56dcb70