### PR TITLE
Add Windows CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Compile
+      run: scripts\sc-compile.bat
+      shell: cmd
+    - name: Smoke test
+      run: |
+        if (!(Test-Path 'dist\kbdlayoutmon.exe')) { throw 'Missing executable' }
+        if (!(Test-Path 'dist\kbdlayoutmonhook.dll')) { throw 'Missing DLL' }
+      shell: pwsh


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow using a Windows runner
- compile the project with `sc-compile.bat`
- check that build artifacts exist

## Testing
- `scripts/run_tests.sh` *(fails: catch2 missing)*

------
https://chatgpt.com/codex/tasks/task_e_686f0ed87ab08325bdb664e70515569b