### PR TITLE
Add optional config path support

### DIFF
--- a/configuration.cpp
+++ b/configuration.cpp
@@ -10,12 +10,12 @@ extern HINSTANCE g_hInst; // Provided by the executable
 // Global configuration instance shared across modules
 Configuration g_config;
 
-void Configuration::load(const std::wstring& path) {
+void Configuration::load(std::optional<std::wstring> path) {
     std::wstring fullPath;
 
-    if (!path.empty()) {
-        m_lastPath = path;
-        fullPath = path;
+    if (path && !path->empty()) {
+        m_lastPath = *path;
+        fullPath = *path;
     } else if (!m_lastPath.empty()) {
         fullPath = m_lastPath;
     } else {

--- a/configuration.h
+++ b/configuration.h
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <string>
+#include <optional>
 
 class Configuration {
 public:
@@ -11,7 +12,9 @@ public:
     // Load configuration from the given path. If no path is provided,
     // the previously loaded path is used. When no path has been loaded
     // yet, the default configuration file next to the executable is used.
-    void load(const std::wstring& path = L"");
+    //
+    // Passing std::nullopt behaves the same as calling without an argument.
+    void load(std::optional<std::wstring> path = std::nullopt);
 
 private:
     std::wstring m_lastPath; // remembers the path of the last loaded config

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,7 @@ MAX_LOG_SIZE_MB=10 # Rotate log when it exceeds this size in megabytes
 
 Changes to `kbdlayoutmon.config` are picked up automatically while the program is running.
 Debug logging can also be toggled on or off at runtime from the tray icon menu.
+You can specify an alternate configuration file on startup using `--config <path>`.
 
 ## Command Line Options
 The executable also accepts a few optional flags which override settings in the


### PR DESCRIPTION
## Summary
- let `Configuration::load` accept `std::optional<std::wstring>`
- document specifying an alternate config file via `--config`

## Testing
- `g++ test_configuration.cpp -std=c++17 -I. -I.. -o test_configuration && ./test_configuration` *(fails: catch2 missing)*

------
https://chatgpt.com/codex/tasks/task_e_686f134fd51c83259fa986ab8da79cfc