### PR TITLE
Centralize WriteLog

### DIFF
--- a/kbdlayoutmon.cpp
+++ b/kbdlayoutmon.cpp
@@ -60,14 +60,6 @@ NOTIFYICONDATA nid;
 HWND g_hwnd = NULL;                // Handle to our message window
 HANDLE g_hConfigThread = NULL;     // Thread monitoring config file
 HANDLE g_hStopConfigEvent = NULL;  // Event to stop config watcher
-
-
-
-// Helper function to write to log file
-extern "C" __declspec(dllexport) void WriteLog(const wchar_t* message) {
-    g_log.write(message);
-}
-
 // Retrieve version information from the executable's version resource
 std::wstring GetVersionString() {
     wchar_t path[MAX_PATH] = {0};

--- a/log.cpp
+++ b/log.cpp
@@ -29,6 +29,10 @@ std::wstring GetLogPath() {
 
 Log g_log;
 
+extern "C" __declspec(dllexport) void WriteLog(const wchar_t* message) {
+    g_log.write(message);
+}
+
 Log::Log() {
     m_running = true;
     m_thread = std::thread(&Log::process, this);

--- a/log.h
+++ b/log.h
@@ -29,3 +29,6 @@ private:
 };
 
 extern Log g_log;
+
+// Exported helper for modules that share the logging system
+extern "C" __declspec(dllexport) void WriteLog(const wchar_t* message);


### PR DESCRIPTION
## Summary
- centralize WriteLog in `log.cpp`
- export WriteLog declaration in `log.h`
- remove old WriteLog helper from `kbdlayoutmon.cpp`

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686f135c22f083258f2d5120a87e3fae