### PR TITLE
Add CMake build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,55 @@
+cmake_minimum_required(VERSION 3.15)
+project(InputMethodMonitor LANGUAGES CXX RC)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(COMMON_SOURCES
+    configuration.cpp
+    log.cpp
+)
+
+# kbdlayoutmon executable
+add_executable(kbdlayoutmon
+    kbdlayoutmon.cpp
+    ${COMMON_SOURCES}
+    resources/res-icon.rc
+    resources/res-versioninfo.rc
+)
+
+# Include directory for rc file header
+target_include_directories(kbdlayoutmon PRIVATE resources)
+
+target_link_libraries(kbdlayoutmon
+    shlwapi
+    user32
+    gdi32
+    ole32
+    advapi32
+    shell32
+    version
+)
+
+# Embed manifest after build on Windows
+if(MSVC)
+    add_custom_command(TARGET kbdlayoutmon POST_BUILD
+        COMMAND mt.exe -nologo -manifest "${CMAKE_CURRENT_SOURCE_DIR}/manifest.xml" -outputresource:"$<TARGET_FILE:kbdlayoutmon>";1
+        COMMENT "Embedding application manifest")
+endif()
+
+# kbdlayoutmonhook DLL
+add_library(kbdlayoutmonhook SHARED
+    kbdlayoutmonhook.cpp
+    ${COMMON_SOURCES}
+)
+
+set_target_properties(kbdlayoutmonhook PROPERTIES PREFIX "")
+
+target_link_libraries(kbdlayoutmonhook
+    shlwapi
+    user32
+    gdi32
+    ole32
+    advapi32
+)
+

--- a/readme.md
+++ b/readme.md
@@ -41,13 +41,27 @@ configuration file. Use `--help` to display a summary at runtime:
 ```
 
 ## Build
-Visual Studio with C++ tools is required. Open a **Developer Command Prompt** for Visual Studio 2022 (or adjust the path in the script) and run:
 
+### Using CMake
+The project can be built with CMake 3.15 or newer. From a *Developer Command Prompt* run:
+
+```batch
+mkdir build
+cd build
+cmake .. -G "Visual Studio 17 2022"
+cmake --build . --config Release
 ```
+
+`kbdlayoutmon.exe` and `kbdlayoutmonhook.dll` will be produced in `build/Release` with resources and the application manifest embedded.
+
+### Batch Script
+Visual Studio with C++ tools is also sufficient. You can run:
+
+```batch
 scripts\sc-compile.bat
 ```
 
-The script compiles `kbdlayoutmon.exe` and `kbdlayoutmonhook.dll` and places the results in the `dist` folder.
+This script drops the resulting binaries into the `dist` folder.
 
 ## Batch Scripts
 Several helper scripts are provided in the `scripts` directory:


### PR DESCRIPTION
## Summary
- add CMakeLists.txt for kbdlayoutmon and kbdlayoutmonhook
- embed manifest and resources in executable build
- document CMake build workflow in `readme.md`

## Testing
- `bash scripts/run_tests.sh` *(fails: catch2 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_686f1360ebe483259971c6315817e678