### PR TITLE
Keep DLL config in sync

### DIFF
--- a/kbdlayoutmonhook.cpp
+++ b/kbdlayoutmonhook.cpp
@@ -282,6 +282,7 @@ BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved) {
         case DLL_PROCESS_ATTACH:
             g_hInst = hinstDLL;
             g_hMutex = CreateMutex(NULL, FALSE, L"Global\\KbdHookMutex");
+            g_config.load();
             {
                 auto it = g_config.settings.find(L"debug");
                 g_debugEnabled = (it != g_config.settings.end() && it->second == L"1");

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Input Method Monitor is a small Windows utility that keeps your default input me
 - Optional debug logging to `kbdlayoutmon.log`.
 
 ## Configuration
-Configuration is read from `kbdlayoutmon.config` located next to the executable. Supported options are:
+Configuration is read from `kbdlayoutmon.config` located next to the executable. The DLL calls the same loader so both modules read this file. Supported options are:
 
 ```
 DEBUG=1       # Enable debug logging (0 to disable)


### PR DESCRIPTION
## Summary
- load configuration in the DLL when it attaches to the process
- mention that both modules read the same config file

## Testing
- `sh scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6874365bb7a0832587ceb21acbfabdb0