### PR TITLE
Fix DLL log linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,13 +6,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(COMMON_SOURCES
     configuration.cpp
-    log.cpp
 )
 
 # kbdlayoutmon executable
 add_executable(kbdlayoutmon
     kbdlayoutmon.cpp
     ${COMMON_SOURCES}
+    log.cpp
     resources/res-icon.rc
     resources/res-versioninfo.rc
 )

--- a/configuration.cpp
+++ b/configuration.cpp
@@ -27,7 +27,7 @@ void Configuration::load(std::optional<std::wstring> path) {
         m_lastPath = fullPath;
     }
 
-    std::wifstream file(fullPath);
+    std::wifstream file(fullPath.c_str());
     if (!file.is_open()) {
         return;
     }

--- a/kbdlayoutmonhook.cpp
+++ b/kbdlayoutmonhook.cpp
@@ -33,6 +33,9 @@ std::condition_variable g_queueCV;
 std::queue<std::pair<std::wstring, std::wstring>> g_taskQueue;
 bool g_workerRunning = false;
 
+void IncrementRefCount();
+void DecrementRefCount();
+
 // Helper function to write to log file via named pipe
 void WriteLog(const std::wstring& message) {
     HANDLE pipe = CreateFileW(L"\\\\.\\pipe\\kbdlayoutmon_log", GENERIC_WRITE, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);

--- a/log.cpp
+++ b/log.cpp
@@ -67,7 +67,7 @@ void Log::write(const std::wstring& message) {
 
 void Log::process() {
     std::wstring path = GetLogPath();
-    m_file.open(path, std::ios::app);
+    m_file.open(path.c_str(), std::ios::app);
     if (!m_file.is_open()) {
         OutputDebugString(L"Failed to open log file.");
     }
@@ -99,7 +99,7 @@ void Log::process() {
                         m_file.close();
                         std::wstring rotated = path + L".1";
                         MoveFileExW(path.c_str(), rotated.c_str(), MOVEFILE_REPLACE_EXISTING);
-                        m_file.open(path, std::ios::out | std::ios::trunc);
+                        m_file.open(path.c_str(), std::ios::out | std::ios::trunc);
                     }
                 }
 


### PR DESCRIPTION
## Summary
- avoid linking log.cpp into the `kbdlayoutmonhook` library
- update file handling for MinGW
- forward declare refcount helpers in the hook

## Testing
- `./scripts/run_tests.sh`
- `x86_64-w64-mingw32-g++ -std=c++17 -DUNICODE -D_UNICODE -shared kbdlayoutmonhook.o configuration.o -o kbdlayoutmonhook.dll -lshlwapi -luser32 -lgdi32 -lole32 -ladvapi32`
- `x86_64-w64-mingw32-g++ -std=c++17 -mwindows kbdlayoutmon.o configuration.o log.o res-icon.o res-versioninfo.o -o kbdlayoutmon.exe -lshlwapi -luser32 -lgdi32 -lole32 -ladvapi32 -lshell32 -lversion`


------
https://chatgpt.com/codex/tasks/task_e_687436536c308325926fba8093ebfa6d