### PR TITLE
Add stop event for log pipe

### DIFF
--- a/log.h
+++ b/log.h
@@ -21,6 +21,7 @@ private:
 
     std::thread m_thread;
     std::thread m_pipeThread;
+    HANDLE m_stopEvent = NULL;
     std::mutex m_mutex;
     std::condition_variable m_cv;
     std::queue<std::wstring> m_queue;


### PR DESCRIPTION
## Summary
- allow graceful shutdown of log pipe listener
- connect pipe asynchronously and exit loop when stop event signals

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6874f9875ec083258c4f8d1e82fa9ea2