### PR TITLE
Sync debug flag across modules

### DIFF
--- a/kbdlayoutmonhook.cpp
+++ b/kbdlayoutmonhook.cpp
@@ -279,6 +279,11 @@ extern "C" __declspec(dllexport) void SetLayoutHotKeyEnabled(bool enabled) {
     ReleaseMutex(g_hMutex);
 }
 
+// Function to update debug logging state
+extern "C" __declspec(dllexport) void SetDebugLoggingEnabled(bool enabled) {
+    g_debugEnabled = enabled;
+}
+
 BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved) {
     UNREFERENCED_PARAMETER(lpReserved);
     switch (fdwReason) {

--- a/log.h
+++ b/log.h
@@ -32,3 +32,5 @@ extern Log g_log;
 
 // Exported helper for modules that share the logging system
 extern "C" __declspec(dllexport) void WriteLog(const wchar_t* message);
+// Exported helper to toggle debug logging state in the DLL
+extern "C" __declspec(dllexport) void SetDebugLoggingEnabled(bool enabled);


### PR DESCRIPTION
## Summary
- export a new `SetDebugLoggingEnabled` helper in **log.h**
- implement `SetDebugLoggingEnabled` in the hook DLL
- load the function from the DLL in `kbdlayoutmon.cpp`
- call the new function whenever the debug logging option toggles

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6874f98550c483258a5d895f7f6b4512