### PR TITLE
Add log message when config file fails to load

### DIFF
--- a/configuration.cpp
+++ b/configuration.cpp
@@ -2,6 +2,7 @@
 #include <windows.h>
 #include <shlwapi.h>
 #include "constants.h"
+#include "log.h"
 #include <fstream>
 #include <algorithm>
 
@@ -29,6 +30,8 @@ void Configuration::load(std::optional<std::wstring> path) {
 
     std::wifstream file(fullPath.c_str());
     if (!file.is_open()) {
+        std::wstring msg = L"Unable to open config file: " + fullPath;
+        WriteLog(msg.c_str());
         return;
     }
 

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Input Method Monitor is a small Windows utility that keeps your default input me
 - Optional debug logging to `kbdlayoutmon.log`.
 
 ## Configuration
-Configuration is read from `kbdlayoutmon.config` located next to the executable. The DLL calls the same loader so both modules read this file. Supported options are:
+Configuration is read from `kbdlayoutmon.config` located next to the executable. The DLL calls the same loader so both modules read this file. By default the file should sit in the same folder as `kbdlayoutmon.exe` (for example `dist\kbdlayoutmon.config` when built with the provided scripts). Supported options are:
 
 ```
 DEBUG=1       # Enable debug logging (0 to disable)


### PR DESCRIPTION
## Summary
- include `log.h` in `configuration.cpp`
- log a message when the configuration file can't be opened
- mention the default location of `kbdlayoutmon.config` in the README

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6874f987e7d88325971f6f884682ebce