### PR TITLE
Sync debug flag and add logging tests

### DIFF
--- a/kbdlayoutmonhook.cpp
+++ b/kbdlayoutmonhook.cpp
@@ -38,6 +38,9 @@ void DecrementRefCount();
 
 // Helper function to write to log file via named pipe
 void WriteLog(const std::wstring& message) {
+    if (!g_debugEnabled)
+        return;
+
     HANDLE pipe = CreateFileW(L"\\\\.\\pipe\\kbdlayoutmon_log", GENERIC_WRITE, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
     if (pipe != INVALID_HANDLE_VALUE) {
         DWORD bytesWritten = 0;
@@ -277,6 +280,11 @@ extern "C" __declspec(dllexport) void SetLayoutHotKeyEnabled(bool enabled) {
     WaitForSingleObject(g_hMutex, INFINITE);
     g_layoutHotKeyEnabled = enabled;
     ReleaseMutex(g_hMutex);
+}
+
+// Function to update debug logging state from the executable
+extern "C" __declspec(dllexport) void SetDebugEnabled(bool enabled) {
+    g_debugEnabled = enabled;
 }
 
 BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved) {

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
 
-g++ -std=c++17 -I/usr/include/catch2 tests/test_configuration.cpp -o tests/run_tests -lCatch2Main -lCatch2 && ./tests/run_tests
+g++ -std=c++17 -I/usr/include/catch2 tests/*.cpp -o tests/run_tests -lCatch2Main -lCatch2 && ./tests/run_tests

--- a/tests/test_logging.cpp
+++ b/tests/test_logging.cpp
@@ -1,0 +1,39 @@
+#include <catch2/catch_test_macros.hpp>
+#include <string>
+
+static bool g_debugEnabled = false;
+static int openCount = 0;
+
+// Stubs for Windows types
+using HANDLE = void*;
+using DWORD = unsigned long;
+#define INVALID_HANDLE_VALUE ((HANDLE)(-1))
+
+static HANDLE CreateFileW(const wchar_t*, DWORD, DWORD, void*, DWORD, DWORD, void*) {
+    ++openCount;
+    return (HANDLE)1; // dummy handle
+}
+static bool WriteFile(HANDLE, const void*, DWORD, DWORD*, void*) { return true; }
+static bool CloseHandle(HANDLE) { return true; }
+
+static void WriteLog(const std::wstring& message) {
+    if (!g_debugEnabled)
+        return;
+    HANDLE pipe = CreateFileW(L"\\\\.\\pipe\\kbdlayoutmon_log", 0, 0, nullptr, 0, 0, nullptr);
+    if (pipe != INVALID_HANDLE_VALUE) {
+        DWORD bytesWritten = 0;
+        WriteFile(pipe, message.c_str(), (DWORD)((message.size() + 1) * sizeof(wchar_t)), &bytesWritten, nullptr);
+        CloseHandle(pipe);
+    }
+}
+
+TEST_CASE("WriteLog stops when debug disabled", "[logging]") {
+    openCount = 0;
+    g_debugEnabled = true;
+    WriteLog(L"first");
+    REQUIRE(openCount == 1);
+
+    g_debugEnabled = false;
+    WriteLog(L"second");
+    REQUIRE(openCount == 1);
+}


### PR DESCRIPTION
## Summary
- stop DLL WriteLog if debug disabled
- allow exe to update DLL debug state
- compile all tests and add a logging toggle test

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6874f97dd790832584ba95dfa28a1147