### PR TITLE
Add Catch2 test target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,3 +53,12 @@ target_link_libraries(kbdlayoutmonhook
     advapi32
 )
 
+# Unit tests
+find_package(Catch2 3 REQUIRED)
+add_executable(run_tests tests/test_configuration.cpp)
+target_include_directories(run_tests PRIVATE tests)
+target_link_libraries(run_tests PRIVATE Catch2::Catch2WithMain)
+
+enable_testing()
+add_test(NAME run_tests COMMAND run_tests)
+

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,9 @@ mkdir build
 cd build
 cmake .. -G "Visual Studio 17 2022"
 cmake --build . --config Release
+cmake --build . --target run_tests
+# or simply
+# ctest
 ```
 
 `kbdlayoutmon.exe` and `kbdlayoutmonhook.dll` will be produced in `build/Release` with resources and the application manifest embedded.


### PR DESCRIPTION
## Summary
- add `run_tests` target using Catch2
- enable CTest integration
- document how to build and run the tests

## Testing
- `cmake -DCMAKE_RC_COMPILER=x86_64-w64-mingw32-windres ..`
- `cmake --build . --target run_tests`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687537572d6883258fb691651020785f