### PR TITLE
Fix watcher thread leak on DLL load failure

### DIFF
--- a/kbdlayoutmon.cpp
+++ b/kbdlayoutmon.cpp
@@ -706,6 +706,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
             ReleaseMutex(g_hInstanceMutex);
             CloseHandle(g_hInstanceMutex);
         }
+        StopConfigWatcher();
         return 1;
     }
 


### PR DESCRIPTION
## Summary
- ensure `StopConfigWatcher()` is called when the hook DLL fails to load

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687537558ac083259863b2e92925f42a