### PR TITLE
Use atomic flags for global control state

### DIFF
--- a/source/log.cpp
+++ b/source/log.cpp
@@ -3,10 +3,11 @@
 #include <fstream>
 #include <shlwapi.h>
 #include <utility>
+#include <atomic>
 #include "configuration.h"
 
 extern HINSTANCE g_hInst; // Provided by the executable or DLL
-extern bool g_debugEnabled;
+extern std::atomic<bool> g_debugEnabled;
 
 namespace {
 std::wstring GetLogPath() {


### PR DESCRIPTION
## Summary
- use `std::atomic<bool>` for runtime flags shared between threads
- drop mutex usage when reading/writing these flags
- adapt logging code to new atomic variable

## Testing
- `cmake -S . -B build` *(fails: No CMAKE_RC_COMPILER)*

------
https://chatgpt.com/codex/tasks/task_e_687f6547e82c8325ba48712714478e37