### PR TITLE
Update Catch2 docs and test script

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,14 @@ configuration file. Use `--help` to display a summary at runtime:
 
 ## Build
 
+### Installing Catch2
+Unit tests depend on [Catch2](https://github.com/catchorg/Catch2). On Debian/Ubuntu install it with:
+
+```bash
+sudo apt install catch2
+```
+
+Alternatively build it from source if your distribution does not provide it.
 ### Using CMake
 The project can be built with CMake 3.15 or newer. From a *Developer Command Prompt* run:
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,4 +1,11 @@
 #!/bin/sh
 set -e
 
-g++ -std=c++17 -I/usr/include/catch2 tests/test_configuration.cpp -o tests/run_tests -lCatch2Main -lCatch2 && ./tests/run_tests
+HEADER="/usr/include/catch2/catch_test_macros.hpp"
+if [ ! -f "$HEADER" ]; then
+    echo "Catch2 headers not found. Install Catch2 (e.g. sudo apt install catch2)" >&2
+    exit 1
+fi
+
+g++ -std=c++17 -I/usr/include/catch2 tests/test_configuration.cpp -o tests/run_tests -lCatch2Main -lCatch2
+./tests/run_tests


### PR DESCRIPTION
## Summary
- document installing Catch2 for running unit tests
- check for Catch2 headers in `run_tests.sh` and print a helpful message if missing

## Testing
- `./scripts/run_tests.sh` (fails when Catch2 not installed)
- `sudo apt-get install -y catch2`
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687f6d7a5b908325b5b76d41daa197b3