### PR TITLE
Fix unsigned conversion for config settings

### DIFF
--- a/source/configuration.cpp
+++ b/source/configuration.cpp
@@ -79,14 +79,20 @@ void Configuration::load(std::optional<std::wstring> path) {
 
         if (key == L"temp_hotkey_timeout") {
             try {
-                int timeout = std::stoi(value);
+                if (!value.empty() && value[0] == L'-') {
+                    throw std::invalid_argument("negative");
+                }
+                unsigned long timeout = std::stoul(value);
                 settings[key] = std::to_wstring(timeout);
             } catch (...) {
                 settings[key] = L"10000";
             }
         } else if (key == L"max_log_size_mb") {
             try {
-                int size = std::stoi(value);
+                if (!value.empty() && value[0] == L'-') {
+                    throw std::invalid_argument("negative");
+                }
+                unsigned long size = std::stoul(value);
                 settings[key] = std::to_wstring(size);
             } catch (...) {
                 settings[key] = L"10";

--- a/tests/config_parser.h
+++ b/tests/config_parser.h
@@ -45,14 +45,20 @@ inline std::map<std::wstring, std::wstring> parse_config_lines(const std::vector
 
         if (key == L"temp_hotkey_timeout") {
             try {
-                int timeout = std::stoi(value);
+                if (!value.empty() && value[0] == L'-') {
+                    throw std::invalid_argument("negative");
+                }
+                unsigned long timeout = std::stoul(value);
                 settings[key] = std::to_wstring(timeout);
             } catch (...) {
                 settings[key] = L"10000";
             }
         } else if (key == L"max_log_size_mb") {
             try {
-                int size = std::stoi(value);
+                if (!value.empty() && value[0] == L'-') {
+                    throw std::invalid_argument("negative");
+                }
+                unsigned long size = std::stoul(value);
                 settings[key] = std::to_wstring(size);
             } catch (...) {
                 settings[key] = L"10";

--- a/tests/test_configuration.cpp
+++ b/tests/test_configuration.cpp
@@ -48,6 +48,16 @@ TEST_CASE("Whitespace handling", "[config]") {
     REQUIRE(settings[L"max_log_size_mb"] == L"10");
 }
 
+TEST_CASE("Negative values fallback", "[config]") {
+    std::vector<std::wstring> lines = {
+        L"TEMP_HOTKEY_TIMEOUT=-5000",
+        L"MAX_LOG_SIZE_MB=-2"
+    };
+    auto settings = parse_config_lines(lines);
+    REQUIRE(settings[L"temp_hotkey_timeout"] == L"10000");
+    REQUIRE(settings[L"max_log_size_mb"] == L"10");
+}
+
 TEST_CASE("Reload custom config file", "[config]") {
     namespace fs = std::filesystem;
     fs::path dir = fs::temp_directory_path() / "immon_test";


### PR DESCRIPTION
## Summary
- use `std::stoul` to read numeric config values
- check for negative inputs and fall back to defaults
- test negative numbers fall back to defaults

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687fa5f9bb4c8325bfa398878237b035