### PR TITLE
Add build2 build system

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,17 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Compile
-      run: scripts\sc-compile.bat
-      shell: cmd
+    - name: Configure
+      run: b configure
+      shell: bash
+    - name: Build
+      run: b
+      shell: bash
+    - name: Test
+      run: b test
+      shell: bash
     - name: Smoke test
       run: |
-        if (!(Test-Path 'dist\kbdlayoutmon.exe')) { throw 'Missing executable' }
-        if (!(Test-Path 'dist\kbdlayoutmonhook.dll')) { throw 'Missing DLL' }
+        if (!(Test-Path 'kbdlayoutmon.exe')) { throw 'Missing executable' }
+        if (!(Test-Path 'kbdlayoutmonhook.dll')) { throw 'Missing DLL' }
       shell: pwsh

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.dll
 *.exe
 *.res
+/build/
 
 # Logs
 *.log

--- a/buildfile
+++ b/buildfile
@@ -1,0 +1,32 @@
+using cxx
+using test
+
+cxx.std = 17
+
+# Build the main executable
+exe{kbdlayoutmon}: \
+  source/kbdlayoutmon.cpp \
+  source/configuration.cpp \
+  source/log.cpp \
+  resources/res-icon.rc \
+  resources/res-versioninfo.rc \
+  manifest.xml
+
+# Build the hook DLL
+lib{kbdlayoutmonhook}: \
+  source/kbdlayoutmonhook.cpp \
+  source/configuration.cpp
+
+# Unit tests
+exe{run_tests}: tests/test_configuration.cpp
+
+# Register test target
+test{run_tests}
+
+# Include paths
+cxx.poptions += -Isource -Iresources -Itests
+
+# Link with Windows libraries
+winlibs = lib{shlwapi} lib{user32} lib{gdi32} lib{ole32} lib{advapi32}
+exe{kbdlayoutmon}: libs += $winlibs lib{shell32} lib{version}
+lib{kbdlayoutmonhook}: libs += $winlibs

--- a/manifest
+++ b/manifest
@@ -1,0 +1,5 @@
+: 1
+name: input-method-monitor
+version: 0.1.0
+summary: Input Method Monitor
+license: MIT

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,18 @@ cmake --build . --target run_tests
 
 `kbdlayoutmon.exe` and `kbdlayoutmonhook.dll` will be produced in `build/Release` with resources and the application manifest embedded.
 
+### Using build2
+The repository also ships with a basic [build2](https://build2.org/) setup. After installing
+the build2 toolchain run:
+
+```bash
+b configure
+b
+b test
+```
+
+Executables will appear in the current directory when the build completes.
+
 ### Batch Script
 Visual Studio with C++ tools is also sufficient. You can run:
 


### PR DESCRIPTION
## Summary
- add build2 buildfile and manifest
- update README with build2 instructions
- add build folder to `.gitignore`
- switch CI to use build2

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_688003726f3083259d475ec4a3cd519e