### PR TITLE
Document public API with Doxygen

### DIFF
--- a/source/configuration.cpp
+++ b/source/configuration.cpp
@@ -8,7 +8,7 @@
 
 extern HINSTANCE g_hInst; // Provided by the executable
 
-// Global configuration instance shared across modules
+/// Global configuration instance shared across modules.
 Configuration g_config;
 
 void Configuration::load(std::optional<std::wstring> path) {

--- a/source/configuration.h
+++ b/source/configuration.h
@@ -4,23 +4,40 @@
 #include <string>
 #include <optional>
 
+/**
+ * @brief Manages configuration settings loaded from a file.
+ *
+ * Keys are stored in lower case to simplify lookups.  Values are kept
+ * verbatim after trimming whitespace.
+ */
 class Configuration {
 public:
-    // map containing lowercased keys from the config file
+    /// Map containing lower‑cased keys from the configuration file.
     std::map<std::wstring, std::wstring> settings;
 
-    // Load configuration from the given path. If no path is provided,
-    // the previously loaded path is used. When no path has been loaded
-    // yet, the default configuration file next to the executable is used.
-    //
-    // Passing std::nullopt behaves the same as calling without an argument.
+    /**
+     * @brief Load configuration from a file.
+     *
+     * If @p path is empty or @c std::nullopt, the previously loaded
+     * path is reused. When no file has been loaded yet, the default
+     * configuration file next to the executable is used.
+     *
+     * @param path Optional path to a configuration file.
+     * @return void
+     * @sideeffects Updates #settings and remembers the last path.
+     */
     void load(std::optional<std::wstring> path = std::nullopt);
 
-    // Retrieve the path of the last loaded configuration file
+    /**
+     * @brief Retrieve the path of the last loaded configuration file.
+     * @return Absolute path of the last successfully loaded file.
+     */
     std::wstring getLastPath() const;
 
 private:
-    std::wstring m_lastPath; // remembers the path of the last loaded config
+    /// Stores the path of the most recently loaded configuration file.
+    std::wstring m_lastPath;
 };
 
-extern Configuration g_config; // Shared configuration instance
+/// Global configuration instance shared across modules.
+extern Configuration g_config;

--- a/source/constants.h
+++ b/source/constants.h
@@ -1,4 +1,5 @@
 #pragma once
 #include <string>
 
+/// Name of the default configuration file shipped with the application.
 inline const std::wstring configFile = L"kbdlayoutmon.config";

--- a/source/kbdlayoutmon.cpp
+++ b/source/kbdlayoutmon.cpp
@@ -561,6 +561,11 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
     return DefWindowProc(hwnd, uMsg, wParam, lParam);
 }
 
+/**
+ * @brief Application entry point.
+ *
+ * Initializes the tray icon, loads the hook DLL and enters the message loop.
+ */
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow) {
     g_hInst = hInstance;
 

--- a/source/kbdlayoutmonhook.cpp
+++ b/source/kbdlayoutmonhook.cpp
@@ -171,7 +171,10 @@ void StopWorkerThread() {
         g_workerThread.join();
 }
 
-// Initialize global state after loading the DLL
+/**
+ * @brief Initialize global state after loading the DLL.
+ * @return TRUE on success.
+ */
 extern "C" __declspec(dllexport) BOOL InitHookModule() {
     g_hMutex = CreateMutex(NULL, FALSE, L"Global\\KbdHookMutex");
     g_config.load();
@@ -181,7 +184,9 @@ extern "C" __declspec(dllexport) BOOL InitHookModule() {
     return TRUE;
 }
 
-// Cleanup state before unloading the DLL
+/**
+ * @brief Cleanup state before the DLL is unloaded.
+ */
 extern "C" __declspec(dllexport) void CleanupHookModule() {
     StopWorkerThread();
     if (g_hMutex) {
@@ -215,7 +220,10 @@ LRESULT CALLBACK ShellProc(int nCode, WPARAM wParam, LPARAM lParam) {
     return CallNextHookEx(g_hHook, nCode, wParam, lParam);
 }
 
-// Function to install the global hook
+/**
+ * @brief Install the shell hook used to monitor layout changes.
+ * @return TRUE if the hook was successfully installed.
+ */
 extern "C" __declspec(dllexport) BOOL InstallGlobalHook() {
     if (g_lastHKL == NULL) {
         g_lastHKL = GetKeyboardLayout(0);
@@ -235,7 +243,9 @@ extern "C" __declspec(dllexport) BOOL InstallGlobalHook() {
     return TRUE;
 }
 
-// Function to uninstall the global hook
+/**
+ * @brief Remove the previously installed shell hook.
+ */
 extern "C" __declspec(dllexport) void UninstallGlobalHook() {
     if (g_hHook != NULL) {
         if (UnhookWindowsHookEx(g_hHook)) {
@@ -272,31 +282,47 @@ void DecrementRefCount() {
     ReleaseMutex(g_hMutex);
 }
 
-// Function to get the Language HotKey enabled state
+/**
+ * @brief Query whether the Windows "Language" hotkey is enabled.
+ */
 extern "C" __declspec(dllexport) bool GetLanguageHotKeyEnabled() {
     return g_languageHotKeyEnabled.load();
 }
 
-// Function to get the Layout HotKey enabled state
+/**
+ * @brief Query whether the Windows "Layout" hotkey is enabled.
+ */
 extern "C" __declspec(dllexport) bool GetLayoutHotKeyEnabled() {
     return g_layoutHotKeyEnabled.load();
 }
 
-// Function to set the Language HotKey enabled state
+/**
+ * @brief Set the Language hotkey state shared with the executable.
+ * @param enabled New enabled flag.
+ */
 extern "C" __declspec(dllexport) void SetLanguageHotKeyEnabled(bool enabled) {
     g_languageHotKeyEnabled = enabled;
 }
 
-// Function to set the Layout HotKey enabled state
+/**
+ * @brief Set the Layout hotkey state shared with the executable.
+ * @param enabled New enabled flag.
+ */
 extern "C" __declspec(dllexport) void SetLayoutHotKeyEnabled(bool enabled) {
     g_layoutHotKeyEnabled = enabled;
 }
 
-// Function to update debug logging state
+/**
+ * @brief Update debug logging state for the DLL.
+ * @param enabled When true, log messages are written.
+ */
 extern "C" __declspec(dllexport) void SetDebugLoggingEnabled(bool enabled) {
     g_debugEnabled = enabled;
 }
 
+/**
+ * @brief Standard DLL entry point called by the loader.
+ */
 BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved) {
     UNREFERENCED_PARAMETER(lpReserved);
     switch (fdwReason) {

--- a/source/log.cpp
+++ b/source/log.cpp
@@ -28,6 +28,7 @@ std::wstring GetLogPath() {
 }
 }
 
+/// Global log instance used by the executable and DLL.
 Log g_log;
 
 extern "C" __declspec(dllexport) void WriteLog(const wchar_t* message) {

--- a/source/log.h
+++ b/source/log.h
@@ -7,21 +7,35 @@
 #include <queue>
 #include <fstream>
 
+/**
+ * @brief Threaded log writer used by the application and hook DLL.
+ */
 class Log {
 public:
+    /// Construct the logging subsystem and start worker threads.
     Log();
+    /// Ensure worker threads are stopped and the log file closed.
     ~Log();
 
+    /**
+     * @brief Queue a message for asynchronous logging.
+     * @param message Text to append to the log file.
+     * @sideeffects Signals the worker thread to write the entry.
+     */
     void write(const std::wstring& message);
+
+    /// Flush queued messages and terminate the worker threads.
     void shutdown();
 
 private:
+    /// Background worker that writes queued messages to disk.
     void process();
+    /// Listener thread that accepts messages via a named pipe.
     void pipeListener();
 
-    std::thread m_thread;
-    std::thread m_pipeThread;
-    HANDLE m_stopEvent = NULL;
+    std::thread m_thread;      ///< Log writer thread.
+    std::thread m_pipeThread;  ///< Named pipe listener thread.
+    HANDLE m_stopEvent = NULL; ///< Event to wake threads for shutdown.
     std::mutex m_mutex;
     std::condition_variable m_cv;
     std::queue<std::wstring> m_queue;
@@ -29,9 +43,17 @@ private:
     bool m_running = false;
 };
 
+/// Global log instance used by all modules.
 extern Log g_log;
 
-// Exported helper for modules that share the logging system
+/**
+ * @brief Write a message to the shared log.
+ * @param message Null‑terminated string to append.
+ */
 extern "C" __declspec(dllexport) void WriteLog(const wchar_t* message);
-// Exported helper to toggle debug logging state in the DLL
+
+/**
+ * @brief Enable or disable debug logging in the DLL.
+ * @param enabled Set to @c true to allow log messages to be recorded.
+ */
 extern "C" __declspec(dllexport) void SetDebugLoggingEnabled(bool enabled);

--- a/source/winreg_handle.h
+++ b/source/winreg_handle.h
@@ -2,19 +2,26 @@
 
 #include <windows.h>
 
-// RAII wrapper for Windows registry handles
+/**
+ * @brief RAII wrapper for Windows registry handles.
+ */
 class WinRegHandle {
 public:
+    /// Construct an empty wrapper that owns no handle.
     WinRegHandle() noexcept : m_hKey(nullptr) {}
+    /// Take ownership of an existing handle.
     explicit WinRegHandle(HKEY hKey) noexcept : m_hKey(hKey) {}
+    /// Close the wrapped handle on destruction.
     ~WinRegHandle() { reset(); }
 
     WinRegHandle(const WinRegHandle&) = delete;
     WinRegHandle& operator=(const WinRegHandle&) = delete;
 
+    /// Move constructor transfers ownership.
     WinRegHandle(WinRegHandle&& other) noexcept : m_hKey(other.m_hKey) {
         other.m_hKey = nullptr;
     }
+    /// Move assignment transfers ownership of the handle.
     WinRegHandle& operator=(WinRegHandle&& other) noexcept {
         if (this != &other) {
             reset();
@@ -24,22 +31,23 @@ public:
         return *this;
     }
 
-    // Retrieve the underlying handle
+    /// Retrieve the underlying handle without transferring ownership.
     HKEY get() const noexcept { return m_hKey; }
 
-    // Pointer to receive a handle from functions like RegOpenKeyEx
+    /// Pointer to receive a handle from APIs like RegOpenKeyEx.
     HKEY* receive() noexcept {
         reset();
         return &m_hKey;
     }
 
-    // Release ownership without closing
+    /// Release ownership without closing the handle.
     HKEY release() noexcept {
         HKEY tmp = m_hKey;
         m_hKey = nullptr;
         return tmp;
     }
 
+    /// Close the current handle and optionally replace it.
     void reset(HKEY hKey = nullptr) noexcept {
         if (m_hKey) {
             RegCloseKey(m_hKey);
@@ -47,7 +55,9 @@ public:
         m_hKey = hKey;
     }
 
+    /// True if a valid handle is held.
     explicit operator bool() const noexcept { return m_hKey != nullptr; }
+    /// Implicit conversion to the raw handle type.
     operator HKEY() const noexcept { return m_hKey; }
 
 private:


### PR DESCRIPTION
## Summary
- document configuration system and global instance
- add API documentation to constants, logging, and registry wrappers
- describe exported hook functions
- briefly document program entry point

## Testing
- `g++ -std=c++17 tests/test_configuration.cpp -o run_tests $(pkg-config --cflags --libs catch2-with-main)`
- `./run_tests`

------
https://chatgpt.com/codex/tasks/task_e_688a364325b083258add10d4d5947072