### PR TITLE
Add CLI flags and verbose mode

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,8 +36,14 @@ configuration file. Use `--help` to display a summary at runtime:
 
 ```
 --config <path>  Load configuration from the specified file
+--cli        Run in command line mode (no tray icon)
+--verbose    Print log messages to the console
 --no-tray    Run without the system tray icon
 --debug      Enable debug logging
+--tray-icon <0|1>          Override tray icon setting
+--temp-hotkey-timeout <ms> Set temporary hotkey timeout
+--log-path <file>          Write log to the specified file
+--max-log-size-mb <n>      Rotate log after n megabytes
 --version    Print the application version and exit
 --help       Show this help text
 ```

--- a/source/log.cpp
+++ b/source/log.cpp
@@ -8,6 +8,7 @@
 
 extern HINSTANCE g_hInst; // Provided by the executable or DLL
 extern std::atomic<bool> g_debugEnabled;
+extern std::atomic<bool> g_verbose;
 
 namespace {
 std::wstring GetLogPath() {
@@ -71,6 +72,18 @@ void Log::write(const std::wstring& message) {
         m_queue.push(message);
     }
     m_cv.notify_one();
+
+    if (g_verbose) {
+        if (AttachConsole(ATTACH_PARENT_PROCESS) || GetConsoleWindow()) {
+            FILE* fp = _wfopen(L"CONOUT$", L"a");
+            if (fp) {
+                fwprintf(fp, L"%s\n", message.c_str());
+                fclose(fp);
+            }
+            if (!GetConsoleWindow())
+                FreeConsole();
+        }
+    }
 }
 
 void Log::process() {

--- a/source/log.h
+++ b/source/log.h
@@ -31,6 +31,9 @@ private:
 
 extern Log g_log;
 
+// Verbose logging flag shared across modules
+extern std::atomic<bool> g_verbose;
+
 // Exported helper for modules that share the logging system
 extern "C" __declspec(dllexport) void WriteLog(const wchar_t* message);
 // Exported helper to toggle debug logging state in the DLL


### PR DESCRIPTION
## Summary
- expand usage text with new command line flags
- implement `--cli` and `--verbose` options
- allow overriding config values from the command line
- support verbose console output in the logger
- document the extra options in the README

## Testing
- `g++ -std=c++17 tests/test_configuration.cpp -Itests -o run_tests -lCatch2Main -lCatch2`
- `./run_tests > /tmp/test.log && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_688a47147f0c8325816dbb95dbe9330d