### PR TITLE
Load config in DLL attach

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Input Method Monitor is a small Windows utility that keeps your default input me
 - Optional debug logging to `kbdlayoutmon.log`.
 
 ## Configuration
-Configuration is read from `kbdlayoutmon.config` located next to the executable. The DLL calls the same loader so both modules read this file. By default the file should sit in the same folder as `kbdlayoutmon.exe` (for example `dist\kbdlayoutmon.config` when built with the provided scripts). Supported options are:
+Configuration is read from `kbdlayoutmon.config` located next to the executable. The DLL loads this file during `DLL_PROCESS_ATTACH` so both modules share the same settings. By default the file should sit in the same folder as `kbdlayoutmon.exe` (for example `dist\kbdlayoutmon.config` when built with the provided scripts). Supported options are:
 
 ```
 DEBUG=1       # Enable debug logging (0 to disable)

--- a/source/kbdlayoutmonhook.cpp
+++ b/source/kbdlayoutmonhook.cpp
@@ -329,6 +329,11 @@ BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved) {
         case DLL_PROCESS_ATTACH:
             g_hInst = hinstDLL;
             DisableThreadLibraryCalls(hinstDLL);
+            g_config.load();
+            {
+                auto it = g_config.settings.find(L"debug");
+                g_debugEnabled = (it != g_config.settings.end() && it->second == L"1");
+            }
             break;
         case DLL_PROCESS_DETACH:
             g_hInst = NULL;


### PR DESCRIPTION
## Summary
- load `g_config` during `DLL_PROCESS_ATTACH`
- set `g_debugEnabled` based on the loaded configuration
- clarify shared configuration file in the docs

## Testing
- `cmake -S . -B build -DCMAKE_RC_COMPILER=x86_64-w64-mingw32-windres`
- `cmake --build build --target run_tests`
- `build/run_tests`

------
https://chatgpt.com/codex/tasks/task_e_688a497363ec83258e4ef3279b239a4d