### PR TITLE
Refactor casts and logging

### DIFF
--- a/source/kbdlayoutmon.cpp
+++ b/source/kbdlayoutmon.cpp
@@ -181,7 +181,7 @@ bool IsLanguageHotKeyEnabled() {
 
         std::wstringstream ss;
         ss << L"Language HotKey value: " << value;
-        WriteLog(ss.str().c_str());
+        WriteLog(ss.str());
 
         return (result == ERROR_SUCCESS && wcscmp(value, L"3") == 0);
     } else {
@@ -203,7 +203,7 @@ bool IsLayoutHotKeyEnabled() {
 
         std::wstringstream ss;
         ss << L"Layout HotKey value: " << value;
-        WriteLog(ss.str().c_str());
+        WriteLog(ss.str());
 
         return (result == ERROR_SUCCESS && wcscmp(value, L"3") == 0);
     } else {
@@ -230,7 +230,7 @@ void ToggleLanguageHotKey(HWND hwnd, bool overrideState = false, bool state = fa
             g_languageHotKeyEnabled = !g_languageHotKeyEnabled;
         }
         RegSetValueEx(hKey.get(), L"Language HotKey", 0, REG_SZ,
-                      (const BYTE*)value,
+                      reinterpret_cast<const BYTE*>(value),
                       (lstrlen(value) + 1) * sizeof(wchar_t));
         //PostMessage(hwnd, WM_UPDATE_TRAY_MENU, 0, 0);
 
@@ -257,7 +257,7 @@ void ToggleLayoutHotKey(HWND hwnd, bool overrideState = false, bool state = fals
             g_layoutHotKeyEnabled = !g_layoutHotKeyEnabled;
         }
         RegSetValueEx(hKey.get(), L"Layout HotKey", 0, REG_SZ,
-                      (const BYTE*)value,
+                      reinterpret_cast<const BYTE*>(value),
                       (lstrlen(value) + 1) * sizeof(wchar_t));
         //PostMessage(hwnd, WM_UPDATE_TRAY_MENU, 0, 0);
 
@@ -280,9 +280,9 @@ void TemporarilyEnableHotKeys(HWND hwnd) {
     LONG result = RegOpenKeyEx(HKEY_CURRENT_USER, L"Keyboard Layout\\Toggle", 0,
                                KEY_SET_VALUE, hKey.receive());
     if (result == ERROR_SUCCESS) {
-        RegSetValueEx(hKey.get(), L"Language HotKey", 0, REG_SZ, (const BYTE*)L"1",
+        RegSetValueEx(hKey.get(), L"Language HotKey", 0, REG_SZ, reinterpret_cast<const BYTE*>(L"1"),
                       (lstrlen(L"1") + 1) * sizeof(wchar_t));
-        RegSetValueEx(hKey.get(), L"Layout HotKey", 0, REG_SZ, (const BYTE*)L"2",
+        RegSetValueEx(hKey.get(), L"Layout HotKey", 0, REG_SZ, reinterpret_cast<const BYTE*>(L"2"),
                       (lstrlen(L"2") + 1) * sizeof(wchar_t));
         WriteLog(L"Temporarily enabled hotkeys.");
 
@@ -717,7 +717,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         DWORD errorCode = GetLastError();
         std::wstringstream ss;
         ss << L"Failed to register window class. Error code: 0x" << std::hex << errorCode;
-        WriteLog(ss.str().c_str());
+        WriteLog(ss.str());
         if (g_hInstanceMutex) {
             ReleaseMutex(g_hInstanceMutex);
             CloseHandle(g_hInstanceMutex);
@@ -743,7 +743,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         DWORD errorCode = GetLastError();
         std::wstringstream ss;
         ss << L"Failed to create message-only window. Error code: 0x" << std::hex << errorCode;
-        WriteLog(ss.str().c_str());
+        WriteLog(ss.str());
         if (g_hInstanceMutex) {
             ReleaseMutex(g_hInstanceMutex);
             CloseHandle(g_hInstanceMutex);
@@ -763,7 +763,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         DWORD errorCode = GetLastError();
         std::wstringstream ss;
         ss << L"Failed to load kbdlayoutmonhook.dll. Error code: 0x" << std::hex << errorCode;
-        WriteLog(ss.str().c_str());
+        WriteLog(ss.str());
         if (g_hInstanceMutex) {
             ReleaseMutex(g_hInstanceMutex);
             CloseHandle(g_hInstanceMutex);
@@ -788,7 +788,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         DWORD errorCode = GetLastError();
         std::wstringstream ss;
         ss << L"Failed to get function addresses from kbdlayoutmonhook.dll. Error code: 0x" << std::hex << errorCode;
-        WriteLog(ss.str().c_str());
+        WriteLog(ss.str());
         FreeLibrary(g_hDll);
         if (g_hInstanceMutex) {
             ReleaseMutex(g_hInstanceMutex);

--- a/source/kbdlayoutmonhook.cpp
+++ b/source/kbdlayoutmonhook.cpp
@@ -79,42 +79,42 @@ void SetDefaultInputMethodInRegistry(const std::wstring& localeID, const std::ws
                                KEY_SET_VALUE, hKey.receive());
     if (result == ERROR_SUCCESS) {
         result = RegSetValueEx(hKey.get(), L"1", 0, REG_SZ,
-                              (const BYTE*)klid.c_str(),
+                              reinterpret_cast<const BYTE*>(klid.c_str()),
                               (DWORD)((klid.size() + 1) * sizeof(wchar_t)));
         if (result == ERROR_SUCCESS) {
             std::wstringstream ss;
             ss << L"Set default input method in registry (Preload) to Locale ID: " << localeID << L", KLID: " << klid;
-            WriteLog(ss.str().c_str());
+            WriteLog(ss.str());
         } else {
             std::wstringstream ss;
             ss << L"Failed to set default input method in registry (Preload). Error code: " << result;
-            WriteLog(ss.str().c_str());
+            WriteLog(ss.str());
         }
     } else {
         std::wstringstream ss;
         ss << L"Failed to open registry key (Preload). Error code: " << result;
-        WriteLog(ss.str().c_str());
+        WriteLog(ss.str());
     }
 
     result = RegOpenKeyEx(HKEY_USERS, L".DEFAULT\\Keyboard Layout\\Preload", 0,
                           KEY_SET_VALUE, hKey.receive());
     if (result == ERROR_SUCCESS) {
         result = RegSetValueEx(hKey.get(), L"1", 0, REG_SZ,
-                              (const BYTE*)klid.c_str(),
+                              reinterpret_cast<const BYTE*>(klid.c_str()),
                               (DWORD)((klid.size() + 1) * sizeof(wchar_t)));
         if (result == ERROR_SUCCESS) {
             std::wstringstream ss;
             ss << L"Set default input method in registry (DEFAULT Preload) to Locale ID: " << localeID << L", KLID: " << klid;
-            WriteLog(ss.str().c_str());
+            WriteLog(ss.str());
         } else {
             std::wstringstream ss;
             ss << L"Failed to set default input method in registry (DEFAULT Preload). Error code: " << result;
-            WriteLog(ss.str().c_str());
+            WriteLog(ss.str());
         }
     } else {
         std::wstringstream ss;
         ss << L"Failed to open registry key (Preload). Error code: " << result;
-        WriteLog(ss.str().c_str());
+        WriteLog(ss.str());
     }
 
     // Update Control Panel International User Profile
@@ -124,21 +124,21 @@ void SetDefaultInputMethodInRegistry(const std::wstring& localeID, const std::ws
     if (result == ERROR_SUCCESS) {
         std::wstring value = localeID + L":" + klid;
         result = RegSetValueEx(hKey.get(), L"InputMethodOverride", 0, REG_SZ,
-                               (const BYTE*)value.c_str(),
+                               reinterpret_cast<const BYTE*>(value.c_str()),
                                (DWORD)((value.size() + 1) * sizeof(wchar_t)));
         if (result == ERROR_SUCCESS) {
             std::wstringstream ss;
             ss << L"Set default input method in registry (InputMethodOverride) to " << value;
-            WriteLog(ss.str().c_str());
+            WriteLog(ss.str());
         } else {
             std::wstringstream ss;
             ss << L"Failed to set default input method in registry (InputMethodOverride). Error code: " << result;
-            WriteLog(ss.str().c_str());
+            WriteLog(ss.str());
         }
     } else {
         std::wstringstream ss;
         ss << L"Failed to open registry key (User Profile). Error code: " << result;
-        WriteLog(ss.str().c_str());
+        WriteLog(ss.str());
     }
 }
 
@@ -205,7 +205,7 @@ LRESULT CALLBACK ShellProc(int nCode, WPARAM wParam, LPARAM lParam) {
             std::wstring klid = GetKLID(hkl);
             std::wstringstream ss;
             ss << L"Keyboard layout changed. Locale ID: " << localeID << L", KLID: " << klid;
-            WriteLog(ss.str().c_str());
+            WriteLog(ss.str());
 
             if (!g_workerRunning)
                 StartWorkerThread();
@@ -235,7 +235,7 @@ extern "C" __declspec(dllexport) BOOL InstallGlobalHook() {
         DWORD errorCode = GetLastError();
         std::wstringstream ss;
         ss << L"Failed to install global hook. Error code: 0x" << std::hex << errorCode;
-        WriteLog(ss.str().c_str());
+        WriteLog(ss.str());
         return FALSE;
     }
     IncrementRefCount();
@@ -254,7 +254,7 @@ extern "C" __declspec(dllexport) void UninstallGlobalHook() {
             DWORD errorCode = GetLastError();
             std::wstringstream ss;
             ss << L"Failed to uninstall global hook. Error code: 0x" << std::hex << errorCode;
-            WriteLog(ss.str().c_str());
+            WriteLog(ss.str());
         }
         g_hHook = NULL;
     }
@@ -268,7 +268,7 @@ void IncrementRefCount() {
     g_refCount++;
     std::wstringstream ss;
     ss << L"Reference count incremented to " << g_refCount;
-    WriteLog(ss.str().c_str());
+    WriteLog(ss.str());
     ReleaseMutex(g_hMutex);
 }
 
@@ -278,7 +278,7 @@ void DecrementRefCount() {
     g_refCount--;
     std::wstringstream ss;
     ss << L"Reference count decremented to " << g_refCount;
-    WriteLog(ss.str().c_str());
+    WriteLog(ss.str());
     ReleaseMutex(g_hMutex);
 }
 


### PR DESCRIPTION
## Summary
- replace C-style casts with `reinterpret_cast` in registry writes
- pass `std::wstring` directly to `WriteLog`

## Testing
- `cmake --build build --target run_tests`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688bdb54088883259a482a17a2a64b0a