### PR TITLE
Support config file comment lines

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,8 @@ LOG_PATH=path\to\logfile # Optional custom log file location
 MAX_LOG_SIZE_MB=10 # Rotate log when it exceeds this size in megabytes
 ```
 
+Lines that begin with `#` or `;` (after trimming whitespace) are treated as comments and ignored.
+
 Changes to `kbdlayoutmon.config` are picked up automatically while the program is running.
 Debug logging can also be toggled on or off at runtime from the tray icon menu.
 You can specify an alternate configuration file on startup using `--config <path>`.

--- a/source/configuration.cpp
+++ b/source/configuration.cpp
@@ -53,6 +53,9 @@ void Configuration::load(std::optional<std::wstring> path) {
         if (currentLine.empty())
             continue;
 
+        if (currentLine[0] == L'#' || currentLine[0] == L';')
+            continue;
+
         size_t eqPos = currentLine.find(L'=');
         if (eqPos == std::wstring::npos)
             continue;

--- a/tests/config_parser.h
+++ b/tests/config_parser.h
@@ -19,6 +19,9 @@ inline std::map<std::wstring, std::wstring> parse_config_lines(const std::vector
         if (currentLine.empty())
             continue;
 
+        if (currentLine[0] == L'#' || currentLine[0] == L';')
+            continue;
+
         size_t eqPos = currentLine.find(L'=');
         if (eqPos == std::wstring::npos)
             continue;

--- a/tests/test_configuration.cpp
+++ b/tests/test_configuration.cpp
@@ -58,6 +58,20 @@ TEST_CASE("Negative values fallback", "[config]") {
     REQUIRE(settings[L"max_log_size_mb"] == L"10");
 }
 
+TEST_CASE("Comment lines are ignored", "[config]") {
+    std::vector<std::wstring> lines = {
+        L"# comment line",
+        L"; another",
+        L"DEBUG=1",
+        L"  #indented",
+        L"TRAY_ICON=1"
+    };
+    auto settings = parse_config_lines(lines);
+    REQUIRE(settings[L"debug"] == L"1");
+    REQUIRE(settings[L"tray_icon"] == L"1");
+    REQUIRE(settings.size() == 2);
+}
+
 TEST_CASE("Reload custom config file", "[config]") {
     namespace fs = std::filesystem;
     fs::path dir = fs::temp_directory_path() / "immon_test";


### PR DESCRIPTION
## Summary
- ignore lines starting with `#` or `;` when parsing configuration files
- test that comment lines are skipped
- mention comment support in `readme.md`

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_688bdb77a9448325a33bb5231dc1fa72