### PR TITLE
Fix quoting for startup registry value

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,8 +57,8 @@ target_link_libraries(kbdlayoutmonhook
 
 # Unit tests
 find_package(Catch2 3 REQUIRED)
-add_executable(run_tests tests/test_configuration.cpp)
-target_include_directories(run_tests PRIVATE tests)
+add_executable(run_tests tests/test_configuration.cpp tests/test_utils.cpp)
+target_include_directories(run_tests PRIVATE tests source)
 target_link_libraries(run_tests PRIVATE Catch2::Catch2WithMain)
 
 enable_testing()

--- a/source/kbdlayoutmon.cpp
+++ b/source/kbdlayoutmon.cpp
@@ -13,6 +13,7 @@
 #include "constants.h"
 #include "log.h"
 #include "winreg_handle.h"
+#include "utils.h"
 
 // Forward declarations
 void ApplyConfig(HWND hwnd);
@@ -144,9 +145,7 @@ void AddToStartup() {
     if (result == ERROR_SUCCESS) {
         wchar_t filePath[MAX_PATH];
         GetModuleFileNameW(NULL, filePath, MAX_PATH);
-        std::wstring quotedPath = L"\"";
-        quotedPath += filePath;
-        quotedPath += L"\"";
+        std::wstring quotedPath = QuotePath(filePath);
         RegSetValueExW(hKey.get(), L"kbdlayoutmon", 0, REG_SZ,
                        reinterpret_cast<const BYTE*>(quotedPath.c_str()),
                        (quotedPath.size() + 1) * sizeof(wchar_t));

--- a/source/utils.h
+++ b/source/utils.h
@@ -1,0 +1,6 @@
+#pragma once
+#include <string>
+
+inline std::wstring QuotePath(const std::wstring& path) {
+    return L"\"" + path + L"\"";
+}

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -1,0 +1,8 @@
+#include <catch2/catch_test_macros.hpp>
+#include <string>
+#include "utils.h"
+
+TEST_CASE("QuotePath wraps the path in quotes") {
+    std::wstring path = L"C:/Program Files/kbdlayoutmon.exe";
+    REQUIRE(QuotePath(path) == L"\"C:/Program Files/kbdlayoutmon.exe\"");
+}


### PR DESCRIPTION
## Summary
- ensure `AddToStartup` quotes the executable path by factoring the logic into `QuotePath`
- expose `QuotePath` helper and test it

## Testing
- `cmake --build build --target run_tests`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688be029b15c8325997abc6dea7a0cd4