### PR TITLE
Remove unused g_mutex globals

### DIFF
--- a/source/kbdlayoutmon.cpp
+++ b/source/kbdlayoutmon.cpp
@@ -57,7 +57,6 @@ SetDebugLoggingEnabledFunc SetDebugLoggingEnabled = NULL;
 InitHookModuleFunc InitHookModule = NULL;
 CleanupHookModuleFunc CleanupHookModule = NULL;
 
-std::mutex g_mutex;
 std::atomic<bool> g_debugEnabled{false}; // Global variable to control debug logging
 std::atomic<bool> g_trayIconEnabled{true}; // Global variable to control tray icon
 bool g_startupEnabled = false; // Global variable to track startup status

--- a/source/kbdlayoutmonhook.cpp
+++ b/source/kbdlayoutmonhook.cpp
@@ -17,7 +17,6 @@
 std::atomic<bool> g_debugEnabled{false};
 HINSTANCE g_hInst = NULL;
 HHOOK g_hHook = NULL;
-std::mutex g_mutex;
 
 #pragma data_seg(".shared")
 HKL g_lastHKL = NULL; // Declare g_lastHKL in the shared memory segment


### PR DESCRIPTION
## Summary
- delete unused `g_mutex` globals from `kbdlayoutmon.cpp` and `kbdlayoutmonhook.cpp`

## Testing
- `cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_RC_COMPILER=x86_64-w64-mingw32-windres`
- `cmake --build build --target kbdlayoutmon -- -j$(nproc)` *(fails: `x86_64-w64-mingw32-windres` usage error)*

------
https://chatgpt.com/codex/tasks/task_e_688be02b9e7c8325bc55a951fa5fbd9f