### PR TITLE
Document Catch2 setup and guard tests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,13 +53,23 @@ configuration file. Use `--help` to display a summary at runtime:
 ## Build
 
 ### Installing Catch2
-Unit tests depend on [Catch2](https://github.com/catchorg/Catch2). On Debian/Ubuntu install it with:
+Unit tests depend on [Catch2](https://github.com/catchorg/Catch2). Install it before attempting to build or run tests.
+
+On Debian/Ubuntu the packaged version can be installed with:
 
 ```bash
 sudo apt install catch2
 ```
 
-Alternatively build it from source if your distribution does not provide it.
+If your distribution does not provide it, build Catch2 from source following the instructions in its repository.
+
+After installation the tests can be executed with:
+
+```bash
+scripts/run_tests.sh
+```
+
+The script checks for the presence of Catch2 headers and will abort with a helpful error message if they are missing.
 ### Using CMake
 The project can be built with CMake 3.15 or newer. From a *Developer Command Prompt* run:
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 set -e
 
-HEADER="/usr/include/catch2/catch_test_macros.hpp"
-if [ ! -f "$HEADER" ]; then
-    echo "Catch2 headers not found. Install Catch2 (e.g. sudo apt install catch2)" >&2
+# Verify that Catch2 is available before attempting to build tests.
+if ! echo '#include <catch2/catch_test_macros.hpp>' | g++ -std=c++17 -x c++ - -fsyntax-only >/dev/null 2>&1; then
+    echo "Catch2 not found. Install Catch2 (e.g. sudo apt install catch2) to build and run tests." >&2
     exit 1
 fi
 
-g++ -std=c++17 -I/usr/include/catch2 tests/test_configuration.cpp -o tests/run_tests -lCatch2Main -lCatch2
+g++ -std=c++17 tests/test_configuration.cpp -o tests/run_tests -lCatch2Main -lCatch2
 ./tests/run_tests


### PR DESCRIPTION
## Summary
- expand README with Catch2 installation instructions and test guidance
- ensure run_tests.sh checks for Catch2 headers before compiling

## Testing
- `scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_689bd01400948325aeff9b3fb3fed649