### PR TITLE
refactor: initialize hook module outside DllMain

### DIFF
--- a/source/kbdlayoutmon.cpp
+++ b/source/kbdlayoutmon.cpp
@@ -804,6 +804,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     // Initialize the hook module now that it's loaded
     if (!InitHookModule()) {
         WriteLog(L"Failed to initialize hook module.");
+        CleanupHookModule();
         FreeLibrary(g_hDll);
         if (g_hInstanceMutex) {
             ReleaseMutex(g_hInstanceMutex);
@@ -818,6 +819,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
     if (!InstallGlobalHook()) {
         WriteLog(L"Failed to install global hook.");
+        CleanupHookModule();
         FreeLibrary(g_hDll);
         if (g_hInstanceMutex) {
             ReleaseMutex(g_hInstanceMutex);

--- a/source/kbdlayoutmonhook.cpp
+++ b/source/kbdlayoutmonhook.cpp
@@ -328,11 +328,6 @@ BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved) {
         case DLL_PROCESS_ATTACH:
             g_hInst = hinstDLL;
             DisableThreadLibraryCalls(hinstDLL);
-            g_config.load();
-            {
-                auto it = g_config.settings.find(L"debug");
-                g_debugEnabled.store(it != g_config.settings.end() && it->second == L"1");
-            }
             break;
         case DLL_PROCESS_DETACH:
             g_hInst = NULL;


### PR DESCRIPTION
## Summary
- move configuration load, mutex creation and worker thread handling into new `InitHookModule` and `CleanupHookModule`
- keep `DllMain` minimal by only storing `hinstDLL` and disabling thread notifications
- call hook module init/cleanup from `kbdlayoutmon.cpp` on load, failure and shutdown

## Testing
- `scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_689bd010ddf88325a09073e903254695