### PR TITLE
Consolidate unit test executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,19 +65,17 @@ endif()
 
 # Unit tests
 find_package(Catch2 3 REQUIRED)
+find_package(Threads REQUIRED)
 
 add_executable(run_tests
     tests/test_configuration.cpp
     tests/test_log.cpp
+    tests/test_utils.cpp
     source/log.cpp
     source/configuration.cpp
 )
 target_include_directories(run_tests PRIVATE tests source)
-find_package(Threads REQUIRED)
 target_link_libraries(run_tests PRIVATE Catch2::Catch2WithMain Threads::Threads)
-add_executable(run_tests tests/test_configuration.cpp tests/test_utils.cpp)
-target_include_directories(run_tests PRIVATE tests source)
-target_link_libraries(run_tests PRIVATE Catch2::Catch2WithMain)
 
 enable_testing()
 add_test(NAME run_tests COMMAND run_tests)


### PR DESCRIPTION
## Summary
- unify run_tests executable to include all test sources
- ensure test target links with Catch2 and Threads

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest`

------
https://chatgpt.com/codex/tasks/task_e_689bd43cedc48325ab5a6790640a0f69