### PR TITLE
Escape quotes in path quoting utility

### DIFF
--- a/source/utils.h
+++ b/source/utils.h
@@ -2,5 +2,14 @@
 #include <string>
 
 inline std::wstring QuotePath(const std::wstring& path) {
-    return L"\"" + path + L"\"";
+    std::wstring escaped;
+    escaped.reserve(path.size());
+    for (wchar_t ch : path) {
+        if (ch == L'"') {
+            escaped += L"\\\""; // escape inner quotes
+        } else {
+            escaped += ch;
+        }
+    }
+    return L"\"" + escaped + L"\"";
 }

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -6,3 +6,8 @@ TEST_CASE("QuotePath wraps the path in quotes") {
     std::wstring path = L"C:/Program Files/kbdlayoutmon.exe";
     REQUIRE(QuotePath(path) == L"\"C:/Program Files/kbdlayoutmon.exe\"");
 }
+
+TEST_CASE("QuotePath escapes internal quotes") {
+    std::wstring path = LR"(C:/Program Files/kbd"layout"mon.exe)";
+    REQUIRE(QuotePath(path) == LR"("C:/Program Files/kbd\"layout\"mon.exe")");
+}


### PR DESCRIPTION
## Summary
- Escape any existing quotes in paths before wrapping them with quotes
- Add unit test for QuotePath handling of embedded quotes

## Testing
- `g++ -std=c++17 tests/test_utils.cpp -lCatch2Main -lCatch2 -pthread -o tests/test_utils && ./tests/test_utils`
- `g++ -std=c++17 tests/test_configuration.cpp source/configuration.cpp -lCatch2Main -lCatch2 -pthread -o tests/test_configuration && ./tests/test_configuration`
- `g++ -std=c++17 tests/test_log.cpp source/log.cpp source/configuration.cpp -lCatch2Main -lCatch2 -pthread -o tests/test_log && ./tests/test_log`


------
https://chatgpt.com/codex/tasks/task_e_689bdc3104ac8325be2deb54b8650fa6