### PR TITLE
Guard configuration access with mutex-locked API

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -7,5 +7,5 @@ if ! echo '#include <catch2/catch_test_macros.hpp>' | g++ -std=c++17 -x c++ - -f
     exit 1
 fi
 
-g++ -std=c++17 tests/test_configuration.cpp -o tests/run_tests -lCatch2Main -lCatch2
+g++ -std=c++17 tests/test_configuration.cpp source/configuration.cpp -o tests/run_tests -lCatch2Main -lCatch2
 ./tests/run_tests

--- a/source/configuration.h
+++ b/source/configuration.h
@@ -39,14 +39,14 @@ public:
      * @param key Lower-cased configuration key to look up.
      * @return Optional containing the value if the key exists.
      */
-    std::optional<std::wstring> get(const std::wstring& key) const;
+    std::optional<std::wstring> getSetting(const std::wstring& key) const;
 
     /**
      * @brief Set the value for @p key.
      * @param key Lower-cased configuration key.
      * @param value Value to store.
      */
-    void set(const std::wstring& key, const std::wstring& value);
+    void setSetting(const std::wstring& key, const std::wstring& value);
 
 private:
     /// Map containing lower-cased keys from the configuration file.

--- a/source/kbdlayoutmon.cpp
+++ b/source/kbdlayoutmon.cpp
@@ -347,7 +347,7 @@ void RemoveTrayIcon() {
 
 // Apply configuration values to runtime settings
 void ApplyConfig(HWND hwnd) {
-    auto debugVal = g_config.get(L"debug");
+    auto debugVal = g_config.getSetting(L"debug");
     bool newDebug = (debugVal && *debugVal == L"1");
     if (newDebug != g_debugEnabled.load()) {
         g_debugEnabled.store(newDebug);
@@ -356,7 +356,7 @@ void ApplyConfig(HWND hwnd) {
     }
 
     bool tray = true;
-    auto trayVal = g_config.get(L"tray_icon");
+    auto trayVal = g_config.getSetting(L"tray_icon");
     if (trayVal)
         tray = *trayVal != L"0";
     if (tray != g_trayIconEnabled.load()) {
@@ -371,7 +371,7 @@ void ApplyConfig(HWND hwnd) {
         }
     }
 
-    auto timeoutVal = g_config.get(L"temp_hotkey_timeout");
+    auto timeoutVal = g_config.getSetting(L"temp_hotkey_timeout");
     if (timeoutVal) {
         g_tempHotKeyTimeout =
             std::wcstoul(timeoutVal->c_str(), nullptr, 10);
@@ -512,7 +512,7 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
                 case ID_TRAY_OPEN_LOG:
                 {
                     wchar_t logPath[MAX_PATH] = {0};
-                    auto val = g_config.get(L"log_path");
+                    auto val = g_config.getSetting(L"log_path");
                     if (val && !val->empty()) {
                         lstrcpynW(logPath, val->c_str(), MAX_PATH);
                     } else if (g_hInst) {
@@ -625,18 +625,18 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
             } else if (wcscmp(argv[i], L"--no-tray") == 0) {
                 g_trayIconEnabled.store(false);
             } else if (wcscmp(argv[i], L"--tray-icon") == 0 && i + 1 < argc) {
-                g_config.set(L"tray_icon", argv[i + 1]);
+                g_config.setSetting(L"tray_icon", argv[i + 1]);
                 g_trayIconEnabled.store(wcscmp(argv[i + 1], L"0") != 0);
                 ++i;
             } else if (wcscmp(argv[i], L"--temp-hotkey-timeout") == 0 && i + 1 < argc) {
-                g_config.set(L"temp_hotkey_timeout", argv[i + 1]);
+                g_config.setSetting(L"temp_hotkey_timeout", argv[i + 1]);
                 g_tempHotKeyTimeout = std::wcstoul(argv[i + 1], nullptr, 10);
                 ++i;
             } else if (wcscmp(argv[i], L"--log-path") == 0 && i + 1 < argc) {
-                g_config.set(L"log_path", argv[i + 1]);
+                g_config.setSetting(L"log_path", argv[i + 1]);
                 ++i;
             } else if (wcscmp(argv[i], L"--max-log-size-mb") == 0 && i + 1 < argc) {
-                g_config.set(L"max_log_size_mb", argv[i + 1]);
+                g_config.setSetting(L"max_log_size_mb", argv[i + 1]);
                 ++i;
             } else if (wcscmp(argv[i], L"--cli") == 0 || wcscmp(argv[i], L"--cli-mode") == 0) {
                 g_cliMode = true;

--- a/source/kbdlayoutmonhook.cpp
+++ b/source/kbdlayoutmonhook.cpp
@@ -177,7 +177,7 @@ void StopWorkerThread() {
 extern "C" __declspec(dllexport) BOOL InitHookModule() {
     g_hMutex.reset(CreateMutex(NULL, FALSE, L"Global\\KbdHookMutex"));
     g_config.load();
-    auto debugVal = g_config.get(L"debug");
+    auto debugVal = g_config.getSetting(L"debug");
     g_debugEnabled.store(debugVal && *debugVal == L"1");
     StartWorkerThread();
     return TRUE;

--- a/source/log.cpp
+++ b/source/log.cpp
@@ -26,7 +26,7 @@ std::atomic<bool> g_verboseLogging{false};
 
 namespace {
 std::wstring GetLogPath() {
-    auto val = g_config.get(L"log_path");
+    auto val = g_config.getSetting(L"log_path");
     if (val && !val->empty()) {
         return *val;
     }
@@ -145,7 +145,7 @@ void Log::process() {
             if (m_file.is_open()) {
                 // Check log file size
                 size_t maxMb = 10;
-                auto val = g_config.get(L"max_log_size_mb");
+                auto val = g_config.getSetting(L"max_log_size_mb");
                 if (val) {
                     try {
                         maxMb = std::stoul(*val);

--- a/tests/test_log.cpp
+++ b/tests/test_log.cpp
@@ -22,13 +22,13 @@ TEST_CASE("Log switches files when path changes", "[log]") {
     fs::path first = dir / "first.log";
     fs::path second = dir / "second.log";
 
-    g_config.set(L"log_path", first.wstring());
+    g_config.setSetting(L"log_path", first.wstring());
     Log log;
 
     log.write(L"one");
     std::this_thread::sleep_for(200ms);
 
-    g_config.set(L"log_path", second.wstring());
+    g_config.setSetting(L"log_path", second.wstring());
     log.write(L"two");
     std::this_thread::sleep_for(200ms);
 


### PR DESCRIPTION
## Summary
- lock entire configuration load under a mutex
- add getSetting/setSetting helpers for guarded access
- switch sources and tests to use new accessors

## Testing
- `./scripts/run_tests.sh`
- `g++ -std=c++17 -c source/kbdlayoutmon.cpp` *(fails: windows.h missing)*
- `g++ -std=c++17 -c source/kbdlayoutmonhook.cpp` *(fails: windows.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_689bdc3681048325a6690900ecaa770f