### PR TITLE
Refactor config parsing into reusable module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(COMMON_SOURCES
     source/configuration.cpp
+    source/config_parser.cpp
 )
 
 # kbdlayoutmon executable
@@ -72,6 +73,7 @@ add_executable(run_tests
     tests/test_utils.cpp
     source/log.cpp
     source/configuration.cpp
+    source/config_parser.cpp
 )
 
 target_include_directories(run_tests PRIVATE tests source)

--- a/buildfile
+++ b/buildfile
@@ -7,6 +7,7 @@ cxx.std = 17
 exe{kbdlayoutmon}: \
   source/kbdlayoutmon.cpp \
   source/configuration.cpp \
+  source/config_parser.cpp \
   source/log.cpp \
   resources/res-icon.rc \
   resources/res-versioninfo.rc \
@@ -15,7 +16,8 @@ exe{kbdlayoutmon}: \
 # Build the hook DLL
 lib{kbdlayoutmonhook}: \
   source/kbdlayoutmonhook.cpp \
-  source/configuration.cpp
+  source/configuration.cpp \
+  source/config_parser.cpp
 
 # Unit tests
 exe{run_tests}: \
@@ -23,7 +25,8 @@ exe{run_tests}: \
   tests/test_log.cpp \
   tests/test_utils.cpp \
   source/log.cpp \
-  source/configuration.cpp
+  source/configuration.cpp \
+  source/config_parser.cpp
 
 # Register test target
 test{run_tests}

--- a/source/config_parser.cpp
+++ b/source/config_parser.cpp
@@ -1,0 +1,80 @@
+#include "config_parser.h"
+#include <algorithm>
+#include <cwctype>
+#include <stdexcept>
+
+std::map<std::wstring, std::wstring> ParseConfigLines(const std::vector<std::wstring>& lines) {
+    std::map<std::wstring, std::wstring> result;
+    for (const std::wstring& line : lines) {
+        std::wstring currentLine = line;
+        size_t start = currentLine.find_first_not_of(L" \t\r\n");
+        if (start == std::wstring::npos)
+            continue;
+        size_t end = currentLine.find_last_not_of(L" \t\r\n");
+        currentLine = currentLine.substr(start, end - start + 1);
+        if (currentLine.empty())
+            continue;
+
+        if (currentLine[0] == L'#' || currentLine[0] == L';')
+            continue;
+
+        size_t eqPos = currentLine.find(L'=');
+        if (eqPos == std::wstring::npos)
+            continue;
+
+        std::wstring key = currentLine.substr(0, eqPos);
+        std::wstring value = currentLine.substr(eqPos + 1);
+
+        auto trim = [](std::wstring& s) {
+            size_t start = s.find_first_not_of(L" \t\r\n");
+            size_t end = s.find_last_not_of(L" \t\r\n");
+            if (start == std::wstring::npos) {
+                s.clear();
+            } else {
+                s = s.substr(start, end - start + 1);
+            }
+        };
+
+        trim(key);
+        trim(value);
+
+        std::transform(key.begin(), key.end(), key.begin(), [](wchar_t c) {
+            return std::towlower(c);
+        });
+
+        if (key == L"temp_hotkey_timeout") {
+            try {
+                if (!value.empty() && value[0] == L'-') {
+                    throw std::invalid_argument("negative");
+                }
+                unsigned long timeout = std::stoul(value);
+                result[key] = std::to_wstring(timeout);
+            } catch (...) {
+                result[key] = L"10000";
+            }
+        } else if (key == L"max_log_size_mb") {
+            try {
+                if (!value.empty() && value[0] == L'-') {
+                    throw std::invalid_argument("negative");
+                }
+                unsigned long size = std::stoul(value);
+                result[key] = std::to_wstring(size);
+            } catch (...) {
+                result[key] = L"10";
+            }
+        } else {
+            result[key] = value;
+        }
+    }
+    return result;
+}
+
+std::map<std::wstring, std::wstring> ParseConfigStream(std::wistream& stream) {
+    std::vector<std::wstring> lines;
+    std::wstring line;
+    while (std::getline(stream, line)) {
+        lines.push_back(line);
+    }
+    return ParseConfigLines(lines);
+}
+

--- a/source/config_parser.h
+++ b/source/config_parser.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+#include <istream>
+
+std::map<std::wstring, std::wstring> ParseConfigLines(const std::vector<std::wstring>& lines);
+std::map<std::wstring, std::wstring> ParseConfigStream(std::wistream& stream);
+

--- a/source/configuration.cpp
+++ b/source/configuration.cpp
@@ -8,9 +8,8 @@
 #endif
 #include "constants.h"
 #include "log.h"
+#include "config_parser.h"
 #include <fstream>
-#include <algorithm>
-#include <cwctype>
 
 #ifndef _WIN32
 using HINSTANCE = void*;
@@ -19,81 +18,6 @@ extern HINSTANCE g_hInst; // Provided by the executable
 
 /// Global configuration instance shared across modules.
 Configuration g_config;
-
-std::map<std::wstring, std::wstring> ParseConfigLines(const std::vector<std::wstring>& lines) {
-    std::map<std::wstring, std::wstring> result;
-    for (const std::wstring& line : lines) {
-        std::wstring currentLine = line;
-        size_t start = currentLine.find_first_not_of(L" \t\r\n");
-        if (start == std::wstring::npos)
-            continue;
-        size_t end = currentLine.find_last_not_of(L" \t\r\n");
-        currentLine = currentLine.substr(start, end - start + 1);
-        if (currentLine.empty())
-            continue;
-
-        if (currentLine[0] == L'#' || currentLine[0] == L';')
-            continue;
-
-        size_t eqPos = currentLine.find(L'=');
-        if (eqPos == std::wstring::npos)
-            continue;
-
-        std::wstring key = currentLine.substr(0, eqPos);
-        std::wstring value = currentLine.substr(eqPos + 1);
-
-        auto trim = [](std::wstring &s) {
-            size_t start = s.find_first_not_of(L" \t\r\n");
-            size_t end = s.find_last_not_of(L" \t\r\n");
-            if (start == std::wstring::npos) {
-                s.clear();
-            } else {
-                s = s.substr(start, end - start + 1);
-            }
-        };
-
-        trim(key);
-        trim(value);
-
-        std::transform(key.begin(), key.end(), key.begin(), [](wchar_t c) {
-            return std::towlower(c);
-        });
-
-        if (key == L"temp_hotkey_timeout") {
-            try {
-                if (!value.empty() && value[0] == L'-') {
-                    throw std::invalid_argument("negative");
-                }
-                unsigned long timeout = std::stoul(value);
-                result[key] = std::to_wstring(timeout);
-            } catch (...) {
-                result[key] = L"10000";
-            }
-        } else if (key == L"max_log_size_mb") {
-            try {
-                if (!value.empty() && value[0] == L'-') {
-                    throw std::invalid_argument("negative");
-                }
-                unsigned long size = std::stoul(value);
-                result[key] = std::to_wstring(size);
-            } catch (...) {
-                result[key] = L"10";
-            }
-        } else {
-            result[key] = value;
-        }
-    }
-    return result;
-}
-
-std::map<std::wstring, std::wstring> ParseConfigStream(std::wistream& stream) {
-    std::vector<std::wstring> lines;
-    std::wstring line;
-    while (std::getline(stream, line)) {
-        lines.push_back(line);
-    }
-    return ParseConfigLines(lines);
-}
 
 void Configuration::load(std::optional<std::wstring> path) {
     std::lock_guard<std::mutex> lock(m_mutex);

--- a/source/configuration.h
+++ b/source/configuration.h
@@ -3,8 +3,6 @@
 #include <map>
 #include <string>
 #include <optional>
-#include <vector>
-#include <istream>
 #include <mutex>
 
 /**
@@ -62,8 +60,3 @@ private:
 /// Global configuration instance shared across modules.
 extern Configuration g_config;
 
-/// Parse configuration from individual lines.
-std::map<std::wstring, std::wstring> ParseConfigLines(const std::vector<std::wstring>& lines);
-
-/// Parse configuration from a wide character stream.
-std::map<std::wstring, std::wstring> ParseConfigStream(std::wistream& stream);

--- a/tests/test_configuration.cpp
+++ b/tests/test_configuration.cpp
@@ -1,11 +1,9 @@
 #include <catch2/catch_test_macros.hpp>
-#include "../source/configuration.h"
+#include "../source/config_parser.h"
 #include <string>
 #include <vector>
 #include <fstream>
 #include <filesystem>
-
-extern "C" void WriteLog(const wchar_t*) {}
 
 TEST_CASE("Valid entries are parsed", "[config]") {
     std::vector<std::wstring> lines = {

--- a/tests/test_log.cpp
+++ b/tests/test_log.cpp
@@ -55,8 +55,8 @@ TEST_CASE("Log rotates file when size limit is exceeded", "[log]") {
     fs::create_directories(dir);
 
     fs::path logPath = dir / "rotate.log";
-    g_config.set(L"log_path", logPath.wstring());
-    g_config.set(L"max_log_size_mb", L"1");
+    g_config.setSetting(L"log_path", logPath.wstring());
+    g_config.setSetting(L"max_log_size_mb", L"1");
     Log log;
 
     // Write a large entry to exceed the configured size (1 MB)


### PR DESCRIPTION
## Summary
- Extracted configuration parsing into new `config_parser` module with `ParseConfigLines` and `ParseConfigStream` utilities.
- Simplified `Configuration::load` to use shared parser and updated tests to include the new header.
- Adjusted build scripts and tests to compile with the shared parser.

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_689be21a3e0883258818283ff5093129