### PR TITLE
Return status from configuration load

### DIFF
--- a/source/configuration.cpp
+++ b/source/configuration.cpp
@@ -95,7 +95,7 @@ std::map<std::wstring, std::wstring> ParseConfigStream(std::wistream& stream) {
     return ParseConfigLines(lines);
 }
 
-void Configuration::load(std::optional<std::wstring> path) {
+bool Configuration::load(std::optional<std::wstring> path) {
     std::lock_guard<std::mutex> lock(m_mutex);
     std::wstring fullPath;
 
@@ -129,10 +129,11 @@ void Configuration::load(std::optional<std::wstring> path) {
     if (!file.is_open()) {
         std::wstring msg = L"Failed to open configuration file: " + fullPath;
         WriteLog(msg.c_str());
-        return;
+        return false;
     }
 
     settings = ParseConfigStream(file);
+    return true;
 }
 
 std::wstring Configuration::getLastPath() const {

--- a/source/configuration.h
+++ b/source/configuration.h
@@ -23,10 +23,11 @@ public:
      * configuration file next to the executable is used.
      *
      * @param path Optional path to a configuration file.
-     * @return void
+     * @return @c true on success, @c false if the file could not be
+     *         opened or parsed.
      * @sideeffects Updates internal settings and remembers the last path.
      */
-    void load(std::optional<std::wstring> path = std::nullopt);
+    bool load(std::optional<std::wstring> path = std::nullopt);
 
     /**
      * @brief Retrieve the path of the last loaded configuration file.

--- a/source/kbdlayoutmon.cpp
+++ b/source/kbdlayoutmon.cpp
@@ -399,9 +399,12 @@ DWORD WINAPI ConfigWatchThread(LPVOID param) {
     for (;;) {
         DWORD wait = WaitForMultipleObjects(2, handles, FALSE, INFINITE);
         if (wait == WAIT_OBJECT_0) {
-            g_config.load();
-            ApplyConfig(hwnd);
-            WriteLog(L"Configuration reloaded.");
+            if (g_config.load()) {
+                ApplyConfig(hwnd);
+                WriteLog(L"Configuration reloaded.");
+            } else {
+                WriteLog(L"Failed to reload configuration.");
+            }
             FindNextChangeNotification(hChange);
         } else if (wait == WAIT_OBJECT_0 + 1) {
             break;
@@ -614,7 +617,9 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     }
 
     // Load configuration before any logging occurs
-    g_config.load(customConfigPath);
+    if (!g_config.load(customConfigPath)) {
+        WriteLog(L"Using default configuration values.");
+    }
     ApplyConfig(NULL);
 
     // Parse command line options after the config file so they override

--- a/source/kbdlayoutmonhook.cpp
+++ b/source/kbdlayoutmonhook.cpp
@@ -176,7 +176,9 @@ void StopWorkerThread() {
  */
 extern "C" __declspec(dllexport) BOOL InitHookModule() {
     g_hMutex.reset(CreateMutex(NULL, FALSE, L"Global\\KbdHookMutex"));
-    g_config.load();
+    if (!g_config.load()) {
+        WriteLog(L"Failed to load configuration.");
+    }
     auto debugVal = g_config.getSetting(L"debug");
     g_debugEnabled.store(debugVal && *debugVal == L"1");
     StartWorkerThread();

--- a/tests/test_configuration.cpp
+++ b/tests/test_configuration.cpp
@@ -1,11 +1,11 @@
 #include <catch2/catch_test_macros.hpp>
 #include "../source/configuration.h"
+#include "../source/log.h"
 #include <string>
 #include <vector>
 #include <fstream>
 #include <filesystem>
 
-extern "C" void WriteLog(const wchar_t*) {}
 
 TEST_CASE("Valid entries are parsed", "[config]") {
     std::vector<std::wstring> lines = {
@@ -104,4 +104,30 @@ TEST_CASE("Reload custom config file", "[config]") {
 
     fs::remove(cfg);
     fs::remove(dir);
+}
+
+TEST_CASE("Load returns status", "[config]") {
+    namespace fs = std::filesystem;
+    fs::path dir = fs::temp_directory_path() / "immon_load_test";
+    fs::create_directories(dir);
+    fs::path cfg = dir / "kbdlayoutmon.config";
+
+    Configuration cfgObj;
+
+    // File does not exist yet
+    REQUIRE_FALSE(cfgObj.load(cfg.wstring()));
+
+    {
+        std::wofstream out(cfg);
+        out << L"DEBUG=1\n";
+    }
+
+    REQUIRE(cfgObj.load(cfg.wstring()));
+    auto debugVal = cfgObj.getSetting(L"debug");
+    REQUIRE(debugVal);
+    REQUIRE(*debugVal == L"1");
+
+    fs::remove(cfg);
+    fs::remove(dir);
+    g_log.shutdown();
 }

--- a/tests/test_log.cpp
+++ b/tests/test_log.cpp
@@ -17,6 +17,7 @@ TEST_CASE("Log switches files when path changes", "[log]") {
     using namespace std::chrono_literals;
     namespace fs = std::filesystem;
     fs::path dir = fs::temp_directory_path() / "immon_log_test";
+    fs::remove_all(dir);
     fs::create_directories(dir);
 
     fs::path first = dir / "first.log";
@@ -52,11 +53,12 @@ TEST_CASE("Log rotates file when size limit is exceeded", "[log]") {
     using namespace std::chrono_literals;
     namespace fs = std::filesystem;
     fs::path dir = fs::temp_directory_path() / "immon_log_rotate_test";
+    fs::remove_all(dir);
     fs::create_directories(dir);
 
     fs::path logPath = dir / "rotate.log";
-    g_config.set(L"log_path", logPath.wstring());
-    g_config.set(L"max_log_size_mb", L"1");
+    g_config.setSetting(L"log_path", logPath.wstring());
+    g_config.setSetting(L"max_log_size_mb", L"1");
     Log log;
 
     // Write a large entry to exceed the configured size (1 MB)


### PR DESCRIPTION
## Summary
- return bool from Configuration::load to indicate success or failure
- log and handle configuration loading failures in main components
- add regression tests for Configuration::load and tidy logging tests

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_689be2cafec4832582273b0d2fc3d866