### PR TITLE
Handle escaped quotes in QuotePath

### DIFF
--- a/source/utils.h
+++ b/source/utils.h
@@ -2,14 +2,37 @@
 #include <string>
 
 inline std::wstring QuotePath(const std::wstring& path) {
-    std::wstring escaped;
-    escaped.reserve(path.size());
+    // Windows command line parsing requires that any backslashes preceding a
+    // quote be doubled and the quote itself escaped. Additionally, any
+    // trailing backslashes must be doubled before the closing quote. This
+    // function performs those transformations and then surrounds the path in
+    // quotes.
+
+    std::wstring result;
+    result.reserve(path.size() * 2 + 2);
+    result.push_back(L'"');
+
+    std::size_t backslashCount = 0;
     for (wchar_t ch : path) {
-        if (ch == L'"') {
-            escaped += L"\\\""; // escape inner quotes
+        if (ch == L'\\') {
+            ++backslashCount;
+        } else if (ch == L'"') {
+            // Double the backslashes and escape the quote
+            result.append(backslashCount * 2, L'\\');
+            result.push_back(L'\\');
+            result.push_back(L'"');
+            backslashCount = 0;
         } else {
-            escaped += ch;
+            // Emit any accumulated backslashes and the current character
+            result.append(backslashCount, L'\\');
+            result.push_back(ch);
+            backslashCount = 0;
         }
     }
-    return L"\"" + escaped + L"\"";
+
+    // Double any trailing backslashes before appending the closing quote
+    result.append(backslashCount * 2, L'\\');
+    result.push_back(L'"');
+
+    return result;
 }

--- a/tests/test_configuration.cpp
+++ b/tests/test_configuration.cpp
@@ -5,7 +5,6 @@
 #include <fstream>
 #include <filesystem>
 
-extern "C" void WriteLog(const wchar_t*) {}
 
 TEST_CASE("Valid entries are parsed", "[config]") {
     std::vector<std::wstring> lines = {

--- a/tests/test_log.cpp
+++ b/tests/test_log.cpp
@@ -55,8 +55,8 @@ TEST_CASE("Log rotates file when size limit is exceeded", "[log]") {
     fs::create_directories(dir);
 
     fs::path logPath = dir / "rotate.log";
-    g_config.set(L"log_path", logPath.wstring());
-    g_config.set(L"max_log_size_mb", L"1");
+    g_config.setSetting(L"log_path", logPath.wstring());
+    g_config.setSetting(L"max_log_size_mb", L"1");
     Log log;
 
     // Write a large entry to exceed the configured size (1 MB)

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -11,3 +11,8 @@ TEST_CASE("QuotePath escapes internal quotes") {
     std::wstring path = LR"(C:/Program Files/kbd"layout"mon.exe)";
     REQUIRE(QuotePath(path) == LR"("C:/Program Files/kbd\"layout\"mon.exe")");
 }
+
+TEST_CASE("QuotePath preserves trailing spaces") {
+    std::wstring path = L"C:/Program Files/kbdlayoutmon.exe  ";
+    REQUIRE(QuotePath(path) == L"\"C:/Program Files/kbdlayoutmon.exe  \"");
+}


### PR DESCRIPTION
## Summary
- Escape Windows paths by doubling backslashes before quotes and the closing quote
- Add unit tests for quoting paths containing quotes and trailing spaces
- Align tests with current Configuration API

## Testing
- `cmake --build build`
- `cd build && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_689be2c86b988325ba041019606e5848