### PR TITLE
Introduce ConfigWatcher RAII class for configuration monitoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ if(WIN32)
 add_executable(kbdlayoutmon
     source/kbdlayoutmon.cpp
     ${COMMON_SOURCES}
+    source/config_watcher.cpp
     source/log.cpp
     resources/res-icon.rc
     resources/res-versioninfo.rc

--- a/source/config_watcher.cpp
+++ b/source/config_watcher.cpp
@@ -1,0 +1,64 @@
+#include "config_watcher.h"
+
+#include <string>
+#include <shlwapi.h>
+
+#include "configuration.h"
+#include "log.h"
+
+// g_hInst is defined in kbdlayoutmon.cpp
+extern HINSTANCE g_hInst;
+// ApplyConfig is implemented in kbdlayoutmon.cpp
+void ApplyConfig(HWND hwnd);
+
+ConfigWatcher::ConfigWatcher(HWND hwnd) : m_hwnd(hwnd) {
+    m_stopEvent.reset(CreateEventW(NULL, TRUE, FALSE, NULL));
+    m_thread.reset(CreateThread(NULL, 0, threadProc, this, 0, NULL));
+}
+
+ConfigWatcher::~ConfigWatcher() {
+    if (m_stopEvent) {
+        SetEvent(m_stopEvent.get());
+    }
+    if (m_thread) {
+        WaitForSingleObject(m_thread.get(), INFINITE);
+        m_thread.reset();
+    }
+    m_stopEvent.reset();
+}
+
+DWORD WINAPI ConfigWatcher::threadProc(LPVOID param) {
+    ConfigWatcher* self = static_cast<ConfigWatcher*>(param);
+    wchar_t dirPath[MAX_PATH];
+    std::wstring cfgPath = g_config.getLastPath();
+    if (cfgPath.empty()) {
+        GetModuleFileNameW(g_hInst, dirPath, MAX_PATH);
+    } else {
+        wcsncpy(dirPath, cfgPath.c_str(), MAX_PATH);
+        dirPath[MAX_PATH - 1] = L'\0';
+    }
+    PathRemoveFileSpecW(dirPath);
+
+    UniqueHandle hChange(FindFirstChangeNotificationW(dirPath, FALSE, FILE_NOTIFY_CHANGE_LAST_WRITE));
+    if (!hChange)
+        return 0;
+
+    HANDLE handles[2] = { hChange.get(), self->m_stopEvent.get() };
+    for (;;) {
+        DWORD wait = WaitForMultipleObjects(2, handles, FALSE, INFINITE);
+        if (wait == WAIT_OBJECT_0) {
+            g_config.load();
+            ApplyConfig(self->m_hwnd);
+            WriteLog(L"Configuration reloaded.");
+            FindNextChangeNotification(hChange);
+        } else if (wait == WAIT_OBJECT_0 + 1) {
+            break;
+        } else {
+            break;
+        }
+    }
+
+    FindCloseChangeNotification(hChange.release());
+    return 0;
+}
+

--- a/source/config_watcher.h
+++ b/source/config_watcher.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <windows.h>
+#include "unique_handle.h"
+
+/**
+ * @brief RAII helper that watches the configuration file for changes.
+ *
+ * The watcher starts monitoring in the constructor and terminates the
+ * background thread when destroyed.
+ */
+class ConfigWatcher {
+public:
+    /// Begin watching for configuration changes affecting @p hwnd.
+    explicit ConfigWatcher(HWND hwnd);
+    /// Stop the watcher thread and clean up resources.
+    ~ConfigWatcher();
+
+    ConfigWatcher(const ConfigWatcher&) = delete;
+    ConfigWatcher& operator=(const ConfigWatcher&) = delete;
+
+private:
+    static DWORD WINAPI threadProc(LPVOID param);
+
+    HWND m_hwnd;            ///< Window receiving update notifications.
+    UniqueHandle m_thread;  ///< Background thread handle.
+    UniqueHandle m_stopEvent; ///< Event used to signal thread shutdown.
+};
+


### PR DESCRIPTION
## Summary
- Add `ConfigWatcher` RAII class that owns config watch thread and stop event
- Replace global thread/event handles with ConfigWatcher usage in `WinMain`
- Include new source file in build

## Testing
- `cmake ..`
- `cmake --build .` *(fails: 'Configuration' has no member named 'setSetting')*


------
https://chatgpt.com/codex/tasks/task_e_689be8ff3a2c8325ab4d0212d7800f5d