### PR TITLE
Refactor log rotation test to match config API

### DIFF
--- a/tests/test_log.cpp
+++ b/tests/test_log.cpp
@@ -55,8 +55,8 @@ TEST_CASE("Log rotates file when size limit is exceeded", "[log]") {
     fs::create_directories(dir);
 
     fs::path logPath = dir / "rotate.log";
-    g_config.setSetting(L"log_path", logPath.wstring());
-    g_config.setSetting(L"max_log_size_mb", L"1");
+    g_config.set(L"log_path", logPath.wstring());
+    g_config.set(L"max_log_size_mb", L"1");
     Log log;
 
     // Write a large entry to exceed the configured size (1 MB)


### PR DESCRIPTION
## Summary
- Use Configuration::set in log rotation test instead of obsolete setSetting

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_689be8fca938832598de2c0d37601c49