### PR TITLE
Add configurable log queue limit and overflow handling

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,7 @@ TRAY_ICON=1   # Show the tray icon (0 to run without it)
 TEMP_HOTKEY_TIMEOUT=10000 # Milliseconds for temporary hotkeys to remain enabled
 LOG_PATH=path\to\logfile # Optional custom log file location
 MAX_LOG_SIZE_MB=10 # Rotate log when it exceeds this size in megabytes
+MAX_QUEUE_SIZE=1000 # Maximum number of log messages buffered before dropping oldest
 ```
 
 Lines that begin with `#` or `;` (after trimming whitespace) are treated as comments and ignored.
@@ -46,6 +47,7 @@ configuration file. Use `--help` to display a summary at runtime:
 --temp-hotkey-timeout <ms>  Override temporary hotkey timeout
 --log-path <path>         Override log file location
 --max-log-size-mb <num>   Override maximum log size
+--max-queue-size <num>    Override maximum queued log messages
 --version                 Print the application version and exit
 --help                    Show this help text
 ```

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -7,5 +7,7 @@ if ! echo '#include <catch2/catch_test_macros.hpp>' | g++ -std=c++17 -x c++ - -f
     exit 1
 fi
 
-g++ -std=c++17 tests/test_configuration.cpp source/configuration.cpp -o tests/run_tests -lCatch2Main -lCatch2
+g++ -std=c++17 tests/test_configuration.cpp tests/test_log.cpp tests/test_utils.cpp \
+    source/configuration.cpp source/log.cpp source/config_parser.cpp -o tests/run_tests \
+    -lCatch2Main -lCatch2 -pthread
 ./tests/run_tests

--- a/source/kbdlayoutmon.cpp
+++ b/source/kbdlayoutmon.cpp
@@ -113,6 +113,7 @@ std::wstring GetUsageString() {
         L"  --temp-hotkey-timeout <ms>  Override temporary hotkey timeout\n"
         L"  --log-path <path>          Override log file location\n"
         L"  --max-log-size-mb <num>    Override max log size\n"
+        L"  --max-queue-size <num>     Override log queue length\n"
         L"  --version    Print the application version and exit\n"
         L"  --help       Show this help message and exit";
 }
@@ -635,6 +636,9 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
             } else if (wcscmp(argv[i], L"--max-log-size-mb") == 0 && i + 1 < argc) {
                 g_config.set(L"max_log_size_mb", argv[i + 1]);
                 ++i;
+            } else if (wcscmp(argv[i], L"--max-queue-size") == 0 && i + 1 < argc) {
+                g_config.set(L"max_queue_size", argv[i + 1]);
+                ++i;
             } else if (wcscmp(argv[i], L"--cli") == 0 || wcscmp(argv[i], L"--cli-mode") == 0) {
                 g_cliMode = true;
                 g_trayIconEnabled.store(false);
@@ -692,6 +696,12 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
             }
         }
         ApplyConfig(NULL);
+        if (auto qval = g_config.get(L"max_queue_size")) {
+            try {
+                g_log.setMaxQueueSize(std::stoul(*qval));
+            } catch (...) {
+            }
+        }
         LocalFree(argv);
     }
 


### PR DESCRIPTION
## Summary
- add maximum queue size to Log with configurable limit
- expose `--max-queue-size` flag and `MAX_QUEUE_SIZE` config setting
- document log queue behaviour and add overflow test

## Testing
- `./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_689be8fece408325ba605d8a6e21a5cb