### PR TITLE
Use std::thread for configuration watcher

### DIFF
--- a/source/config_watcher.h
+++ b/source/config_watcher.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <windows.h>
+#include <thread>
 #include "unique_handle.h"
 
 /**
@@ -20,10 +21,10 @@ public:
     ConfigWatcher& operator=(const ConfigWatcher&) = delete;
 
 private:
-    static DWORD WINAPI threadProc(LPVOID param);
+    static void threadProc(ConfigWatcher* self);
 
     HWND m_hwnd;            ///< Window receiving update notifications.
-    UniqueHandle m_thread;  ///< Background thread handle.
+    std::thread m_thread;   ///< Background thread.
     UniqueHandle m_stopEvent; ///< Event used to signal thread shutdown.
 };
 


### PR DESCRIPTION
## Summary
- replace Windows thread with std::thread in ConfigWatcher
- cleanly stop watcher thread on destruction
- handle thread creation failure

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68a234686f648325aa3c1471d66cc9aa