### PR TITLE
Handle log rotation failures

### DIFF
--- a/source/log.h
+++ b/source/log.h
@@ -75,6 +75,7 @@ private:
     std::wofstream m_file;
     bool m_running = false;
     size_t m_maxQueueSize = 1000;
+    size_t m_suppress = 0; ///< Internal log entries pending that should not trigger rotation.
 };
 
 /// Global log instance used by all modules.


### PR DESCRIPTION
## Summary
- Guard log rotation with error handling for rename failures
- Retry log file opening after rotation and report failures
- Test non-Windows rotation failure handling

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a24ac302888325afb82d9bfbd0326e