### PR TITLE
Handle FindNextChangeNotification failures in config watcher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,9 +73,11 @@ add_executable(run_tests
     tests/test_log.cpp
     tests/test_utils.cpp
     tests/bench_pipe.cpp
+    tests/test_config_watcher.cpp
     source/log.cpp
     source/configuration.cpp
     source/config_parser.cpp
+    source/config_watcher.cpp
 )
 
 target_include_directories(run_tests PRIVATE tests source)

--- a/source/config_watcher.cpp
+++ b/source/config_watcher.cpp
@@ -54,7 +54,11 @@ void ConfigWatcher::threadProc(ConfigWatcher* self) {
             g_config.load();
             ApplyConfig(self->m_hwnd);
             WriteLog(L"Configuration reloaded.");
-            FindNextChangeNotification(hChange);
+            BOOL ok = FindNextChangeNotification(hChange.get());
+            if (!ok) {
+                WriteLog(L"FindNextChangeNotification failed.");
+                break;
+            }
         } else if (wait == WAIT_OBJECT_0 + 1) {
             break;
         } else {

--- a/tests/shlwapi.h
+++ b/tests/shlwapi.h
@@ -1,0 +1,2 @@
+#pragma once
+inline void PathRemoveFileSpecW(wchar_t*) {}

--- a/tests/test_config_watcher.cpp
+++ b/tests/test_config_watcher.cpp
@@ -1,0 +1,30 @@
+#include <catch2/catch_test_macros.hpp>
+#include <thread>
+#include <chrono>
+
+#define private public
+#include "../source/config_watcher.h"
+#undef private
+
+extern HINSTANCE g_hInst;
+void ApplyConfig(HWND) {}
+
+HANDLE (*pCreateEventW)(void*, BOOL, BOOL, LPCWSTR) = [](void*, BOOL, BOOL, LPCWSTR){ return reinterpret_cast<HANDLE>(1); };
+BOOL (*pSetEvent)(HANDLE) = [](HANDLE){ return TRUE; };
+HANDLE (*pFindFirstChangeNotificationW)(LPCWSTR, BOOL, DWORD) = [](LPCWSTR, BOOL, DWORD){ return reinterpret_cast<HANDLE>(1); };
+static int nextCalls = 0;
+BOOL (*pFindNextChangeNotification)(HANDLE) = [](HANDLE){ ++nextCalls; return FALSE; };
+static int closeCalls = 0;
+BOOL (*pFindCloseChangeNotification)(HANDLE) = [](HANDLE){ ++closeCalls; return TRUE; };
+DWORD (*pWaitForMultipleObjects)(DWORD, const HANDLE*, BOOL, DWORD) = [](DWORD, const HANDLE*, BOOL, DWORD) -> DWORD { return WAIT_OBJECT_0; };
+DWORD (*pGetModuleFileNameW)(HINSTANCE, wchar_t* buffer, DWORD) = [](HINSTANCE, wchar_t* buffer, DWORD) -> DWORD { buffer[0] = L'\0'; return 0; };
+
+TEST_CASE("Watcher exits when FindNextChangeNotification fails", "[config_watcher]") {
+    {
+        ConfigWatcher watcher(nullptr);
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    REQUIRE(nextCalls == 1);
+    REQUIRE(closeCalls == 1);
+}
+

--- a/tests/windows.h
+++ b/tests/windows.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <cstdint>
+#include <cwchar>
+
+using HANDLE = void*;
+using HINSTANCE = void*;
+using HWND = void*;
+using DWORD = unsigned long;
+using BOOL = int;
+using LPCWSTR = const wchar_t*;
+
+#define TRUE 1
+#define FALSE 0
+#define WAIT_OBJECT_0 0
+#define INFINITE 0xFFFFFFFF
+#define MAX_PATH 260
+#define FILE_NOTIFY_CHANGE_LAST_WRITE 0x00000010
+#define INVALID_HANDLE_VALUE ((HANDLE)(intptr_t)(-1))
+
+extern "C" {
+    extern HANDLE (*pCreateEventW)(void*, BOOL, BOOL, LPCWSTR);
+    extern BOOL (*pSetEvent)(HANDLE);
+    extern HANDLE (*pFindFirstChangeNotificationW)(LPCWSTR, BOOL, DWORD);
+    extern BOOL (*pFindNextChangeNotification)(HANDLE);
+    extern BOOL (*pFindCloseChangeNotification)(HANDLE);
+    extern DWORD (*pWaitForMultipleObjects)(DWORD, const HANDLE*, BOOL, DWORD);
+    extern DWORD (*pGetModuleFileNameW)(HINSTANCE, wchar_t*, DWORD);
+}
+
+inline HANDLE CreateEventW(void* a, BOOL b, BOOL c, LPCWSTR d) { return pCreateEventW(a,b,c,d); }
+inline BOOL SetEvent(HANDLE h) { return pSetEvent(h); }
+inline HANDLE FindFirstChangeNotificationW(LPCWSTR a, BOOL b, DWORD c) { return pFindFirstChangeNotificationW(a,b,c); }
+inline BOOL FindNextChangeNotification(HANDLE h) { return pFindNextChangeNotification(h); }
+inline BOOL FindCloseChangeNotification(HANDLE h) { return pFindCloseChangeNotification(h); }
+inline DWORD WaitForMultipleObjects(DWORD a, const HANDLE* b, BOOL c, DWORD d) { return pWaitForMultipleObjects(a,b,c,d); }
+inline DWORD GetModuleFileNameW(HINSTANCE inst, wchar_t* buffer, DWORD size) { return pGetModuleFileNameW(inst, buffer, size); }
+inline void CloseHandle(HANDLE) {}


### PR DESCRIPTION
## Summary
- log FindNextChangeNotification failures and stop watching
- add stubs and test ensuring watcher exits when resetting notifications fails

## Testing
- `cmake -S . -B build && cmake --build build && ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a25790611c8325a872268ad8ef2a7b