### PR TITLE
Handle failure paths in ConfigWatcher

### DIFF
--- a/source/config_watcher.h
+++ b/source/config_watcher.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <windows.h>
-#include <thread>
 #include "unique_handle.h"
 
 /**
@@ -21,10 +20,10 @@ public:
     ConfigWatcher& operator=(const ConfigWatcher&) = delete;
 
 private:
-    static void threadProc(ConfigWatcher* self);
+    static DWORD WINAPI threadProc(void* self);
 
     HWND m_hwnd;            ///< Window receiving update notifications.
-    std::thread m_thread;   ///< Background thread.
+    UniqueHandle m_thread;  ///< Background thread handle.
     UniqueHandle m_stopEvent; ///< Event used to signal thread shutdown.
 };
 

--- a/tests/strsafe.h
+++ b/tests/strsafe.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <cwchar>
+#include <cstddef>
+using HRESULT = long;
+inline HRESULT StringCchCopyW(wchar_t* dst, size_t dstSize, const wchar_t* src) {
+    if (!dst || dstSize == 0) return 1;
+    if (src) {
+        std::wcsncpy(dst, src, dstSize - 1);
+        dst[dstSize - 1] = L'\0';
+    } else {
+        dst[0] = L'\0';
+    }
+    return 0;
+}

--- a/tests/test_config_watcher.cpp
+++ b/tests/test_config_watcher.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <thread>
 #include <chrono>
+#include <stdexcept>
 
 #define private public
 #include "../source/config_watcher.h"
@@ -10,6 +11,11 @@ extern HINSTANCE g_hInst;
 void ApplyConfig(HWND) {}
 
 HANDLE (*pCreateEventW)(void*, BOOL, BOOL, LPCWSTR) = [](void*, BOOL, BOOL, LPCWSTR){ return reinterpret_cast<HANDLE>(1); };
+HANDLE (*pCreateThread)(LPVOID, SIZE_T, LPTHREAD_START_ROUTINE, LPVOID, DWORD, DWORD*) =
+    [](LPVOID, SIZE_T, LPTHREAD_START_ROUTINE start, LPVOID param, DWORD, DWORD*) -> HANDLE {
+        start(param);
+        return reinterpret_cast<HANDLE>(1);
+    };
 BOOL (*pSetEvent)(HANDLE) = [](HANDLE){ return TRUE; };
 HANDLE (*pFindFirstChangeNotificationW)(LPCWSTR, BOOL, DWORD) = [](LPCWSTR, BOOL, DWORD){ return reinterpret_cast<HANDLE>(1); };
 static int nextCalls = 0;
@@ -17,14 +23,33 @@ BOOL (*pFindNextChangeNotification)(HANDLE) = [](HANDLE){ ++nextCalls; return FA
 static int closeCalls = 0;
 BOOL (*pFindCloseChangeNotification)(HANDLE) = [](HANDLE){ ++closeCalls; return TRUE; };
 DWORD (*pWaitForMultipleObjects)(DWORD, const HANDLE*, BOOL, DWORD) = [](DWORD, const HANDLE*, BOOL, DWORD) -> DWORD { return WAIT_OBJECT_0; };
+DWORD (*pWaitForSingleObject)(HANDLE, DWORD) = [](HANDLE, DWORD) -> DWORD { return 0; };
 DWORD (*pGetModuleFileNameW)(HINSTANCE, wchar_t* buffer, DWORD) = [](HINSTANCE, wchar_t* buffer, DWORD) -> DWORD { buffer[0] = L'\0'; return 0; };
 
 TEST_CASE("Watcher exits when FindNextChangeNotification fails", "[config_watcher]") {
+    nextCalls = 0;
+    closeCalls = 0;
     {
         ConfigWatcher watcher(nullptr);
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
     REQUIRE(nextCalls == 1);
     REQUIRE(closeCalls == 1);
+}
+
+TEST_CASE("Watcher fails gracefully when CreateEventW fails", "[config_watcher]") {
+    auto origEvent = pCreateEventW;
+    pCreateEventW = [](void*, BOOL, BOOL, LPCWSTR){ return static_cast<HANDLE>(nullptr); };
+    REQUIRE_THROWS_AS(ConfigWatcher(nullptr), std::runtime_error);
+    pCreateEventW = origEvent;
+}
+
+TEST_CASE("Watcher fails gracefully when CreateThread fails", "[config_watcher]") {
+    auto origThread = pCreateThread;
+    pCreateThread = [](LPVOID, SIZE_T, LPTHREAD_START_ROUTINE, LPVOID, DWORD, DWORD*) -> HANDLE {
+        return static_cast<HANDLE>(nullptr);
+    };
+    REQUIRE_THROWS_AS(ConfigWatcher(nullptr), std::runtime_error);
+    pCreateThread = origThread;
 }
 

--- a/tests/windows.h
+++ b/tests/windows.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <cstdint>
 #include <cwchar>
+#include <cstddef>
 
 using HANDLE = void*;
 using HINSTANCE = void*;
@@ -8,6 +9,11 @@ using HWND = void*;
 using DWORD = unsigned long;
 using BOOL = int;
 using LPCWSTR = const wchar_t*;
+using SIZE_T = std::size_t;
+using LPVOID = void*;
+using LPTHREAD_START_ROUTINE = DWORD (*)(LPVOID);
+
+#define WINAPI
 
 #define TRUE 1
 #define FALSE 0
@@ -19,19 +25,23 @@ using LPCWSTR = const wchar_t*;
 
 extern "C" {
     extern HANDLE (*pCreateEventW)(void*, BOOL, BOOL, LPCWSTR);
+    extern HANDLE (*pCreateThread)(LPVOID, SIZE_T, LPTHREAD_START_ROUTINE, LPVOID, DWORD, DWORD*);
     extern BOOL (*pSetEvent)(HANDLE);
     extern HANDLE (*pFindFirstChangeNotificationW)(LPCWSTR, BOOL, DWORD);
     extern BOOL (*pFindNextChangeNotification)(HANDLE);
     extern BOOL (*pFindCloseChangeNotification)(HANDLE);
     extern DWORD (*pWaitForMultipleObjects)(DWORD, const HANDLE*, BOOL, DWORD);
+    extern DWORD (*pWaitForSingleObject)(HANDLE, DWORD);
     extern DWORD (*pGetModuleFileNameW)(HINSTANCE, wchar_t*, DWORD);
 }
 
 inline HANDLE CreateEventW(void* a, BOOL b, BOOL c, LPCWSTR d) { return pCreateEventW(a,b,c,d); }
+inline HANDLE CreateThread(LPVOID a, SIZE_T b, LPTHREAD_START_ROUTINE c, LPVOID d, DWORD e, DWORD* f) { return pCreateThread(a,b,c,d,e,f); }
 inline BOOL SetEvent(HANDLE h) { return pSetEvent(h); }
 inline HANDLE FindFirstChangeNotificationW(LPCWSTR a, BOOL b, DWORD c) { return pFindFirstChangeNotificationW(a,b,c); }
 inline BOOL FindNextChangeNotification(HANDLE h) { return pFindNextChangeNotification(h); }
 inline BOOL FindCloseChangeNotification(HANDLE h) { return pFindCloseChangeNotification(h); }
 inline DWORD WaitForMultipleObjects(DWORD a, const HANDLE* b, BOOL c, DWORD d) { return pWaitForMultipleObjects(a,b,c,d); }
+inline DWORD WaitForSingleObject(HANDLE h, DWORD d) { return pWaitForSingleObject(h,d); }
 inline DWORD GetModuleFileNameW(HINSTANCE inst, wchar_t* buffer, DWORD size) { return pGetModuleFileNameW(inst, buffer, size); }
 inline void CloseHandle(HANDLE) {}


### PR DESCRIPTION
## Summary
- Abort initialization if CreateEventW or CreateThread fail when starting the configuration watcher
- Use StringCchCopyW for safe path copying in the watcher thread
- Test CreateEventW and CreateThread failure handling

## Testing
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68a25ba79f1883259823629049eb753a