### PR TITLE
Refactor tray and hotkey handling into modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ add_executable(kbdlayoutmon
     ${COMMON_SOURCES}
     source/config_watcher.cpp
     source/log.cpp
+    source/tray_icon.cpp
+    source/hotkey_registry.cpp
     resources/res-icon.rc
     resources/res-versioninfo.rc
 )
@@ -75,15 +77,18 @@ add_executable(run_tests
     tests/bench_pipe.cpp
     tests/test_config_watcher.cpp
     tests/test_worker_thread.cpp
+    tests/test_hotkey_registry.cpp
     source/log.cpp
     source/configuration.cpp
     source/config_parser.cpp
     source/config_watcher.cpp
+    source/hotkey_registry.cpp
     source/kbdlayoutmonhook.cpp
 )
 
 target_include_directories(run_tests PRIVATE tests source)
 target_link_libraries(run_tests PRIVATE Catch2::Catch2WithMain)
+target_compile_definitions(run_tests PRIVATE UNIT_TEST)
 
 enable_testing()
 add_test(NAME run_tests COMMAND run_tests)

--- a/source/hotkey_registry.cpp
+++ b/source/hotkey_registry.cpp
@@ -1,0 +1,191 @@
+#include "hotkey_registry.h"
+#include "log.h"
+#include "utils.h"
+#include "winreg_handle.h"
+#include "configuration.h"
+#include <sstream>
+
+// Global variable definitions
+bool g_startupEnabled = false;
+#ifndef UNIT_TEST
+std::atomic<bool> g_languageHotKeyEnabled{false};
+std::atomic<bool> g_layoutHotKeyEnabled{false};
+#endif
+std::atomic<bool> g_tempHotKeysEnabled{false};
+DWORD g_tempHotKeyTimeout = 10000;
+
+// Helper function to check if app is set to launch at startup
+bool IsStartupEnabled() {
+    WinRegHandle hKey;
+    LONG result = RegOpenKeyEx(HKEY_CURRENT_USER,
+                               L"Software\\Microsoft\\Windows\\CurrentVersion\\Run",
+                               0, KEY_READ, hKey.receive());
+    if (result == ERROR_SUCCESS) {
+        wchar_t value[MAX_PATH];
+        DWORD value_length = MAX_PATH;
+        result = RegQueryValueEx(hKey.get(), L"kbdlayoutmon", NULL, NULL,
+                                 (LPBYTE)value, &value_length);
+        return (result == ERROR_SUCCESS);
+    }
+    return false;
+}
+
+// Helper function to add application to startup
+void AddToStartup() {
+    WinRegHandle hKey;
+    LONG result = RegOpenKeyEx(HKEY_CURRENT_USER,
+                               L"Software\\Microsoft\\Windows\\CurrentVersion\\Run",
+                               0, KEY_SET_VALUE, hKey.receive());
+    if (result == ERROR_SUCCESS) {
+        wchar_t filePath[MAX_PATH];
+        GetModuleFileNameW(NULL, filePath, MAX_PATH);
+        std::wstring quotedPath = QuotePath(filePath);
+        RegSetValueExW(hKey.get(), L"kbdlayoutmon", 0, REG_SZ,
+                       reinterpret_cast<const BYTE*>(quotedPath.c_str()),
+                       (quotedPath.size() + 1) * sizeof(wchar_t));
+        WriteLog(L"Added to startup.");
+        g_startupEnabled = true;
+    } else {
+        WriteLog(L"Failed to add to startup.");
+    }
+}
+
+// Helper function to remove application from startup
+void RemoveFromStartup() {
+    WinRegHandle hKey;
+    LONG result = RegOpenKeyEx(HKEY_CURRENT_USER,
+                               L"Software\\Microsoft\\Windows\\CurrentVersion\\Run",
+                               0, KEY_SET_VALUE, hKey.receive());
+    if (result == ERROR_SUCCESS) {
+        RegDeleteValue(hKey.get(), L"kbdlayoutmon");
+        WriteLog(L"Removed from startup.");
+        g_startupEnabled = false;
+    } else {
+        WriteLog(L"Failed to remove from startup.");
+    }
+}
+
+// Helper function to check the status of Language HotKey
+bool IsLanguageHotKeyEnabled() {
+    WinRegHandle hKey;
+    LONG result = RegOpenKeyEx(HKEY_CURRENT_USER, L"Keyboard Layout\\Toggle", 0,
+                               KEY_READ, hKey.receive());
+    if (result == ERROR_SUCCESS) {
+        wchar_t value[2];
+        DWORD value_length = sizeof(value);
+        result = RegQueryValueEx(hKey.get(), L"Language HotKey", NULL, NULL,
+                                 (LPBYTE)value, &value_length);
+        std::wstringstream ss;
+        ss << L"Language HotKey value: " << value;
+        WriteLog(ss.str().c_str());
+        return (result == ERROR_SUCCESS && wcscmp(value, L"3") == 0);
+    } else {
+        WriteLog(L"Failed to open registry key for Language HotKey.");
+    }
+    return false;
+}
+
+// Helper function to check the status of Layout HotKey
+bool IsLayoutHotKeyEnabled() {
+    WinRegHandle hKey;
+    LONG result = RegOpenKeyEx(HKEY_CURRENT_USER, L"Keyboard Layout\\Toggle", 0,
+                               KEY_READ, hKey.receive());
+    if (result == ERROR_SUCCESS) {
+        wchar_t value[2];
+        DWORD value_length = sizeof(value);
+        result = RegQueryValueEx(hKey.get(), L"Layout HotKey", NULL, NULL,
+                                 (LPBYTE)value, &value_length);
+        std::wstringstream ss;
+        ss << L"Layout HotKey value: " << value;
+        WriteLog(ss.str().c_str());
+        return (result == ERROR_SUCCESS && wcscmp(value, L"3") == 0);
+    } else {
+        WriteLog(L"Failed to open registry key for Layout HotKey.");
+    }
+    return false;
+}
+
+// Generic helper to toggle a registry-backed hotkey
+static void ToggleHotKey(HWND hwnd, const wchar_t* valueName,
+                         std::atomic<bool>& enabledFlag,
+                         const wchar_t* onValue, const wchar_t* offValue,
+                         void (*updateFunc)(bool), bool overrideState = false,
+                         bool state = false) {
+    WinRegHandle hKey;
+    LONG result = RegOpenKeyEx(HKEY_CURRENT_USER, L"Keyboard Layout\\Toggle", 0,
+                               KEY_SET_VALUE, hKey.receive());
+    if (result == ERROR_SUCCESS) {
+        const wchar_t* value;
+        if (overrideState) {
+            value = state ? onValue : offValue;
+            enabledFlag.store(state);
+        } else {
+            bool cur = enabledFlag.load();
+            value = cur ? offValue : onValue;
+            enabledFlag.store(!cur);
+        }
+
+        RegSetValueEx(hKey.get(), valueName, 0, REG_SZ,
+                      reinterpret_cast<const BYTE*>(value),
+                      (lstrlen(value) + 1) * sizeof(wchar_t));
+
+        if (updateFunc)
+            updateFunc(enabledFlag.load());
+    }
+}
+
+void ToggleLanguageHotKey(HWND hwnd, bool overrideState, bool state) {
+    g_languageHotKeyEnabled.store(IsLanguageHotKeyEnabled());
+    ToggleHotKey(hwnd, L"Language HotKey", g_languageHotKeyEnabled, L"3", L"1",
+                 SetLanguageHotKeyEnabled, overrideState, state);
+}
+
+void ToggleLayoutHotKey(HWND hwnd, bool overrideState, bool state) {
+    g_layoutHotKeyEnabled.store(IsLayoutHotKeyEnabled());
+    ToggleHotKey(hwnd, L"Layout HotKey", g_layoutHotKeyEnabled, L"3", L"2",
+                 SetLayoutHotKeyEnabled, overrideState, state);
+}
+
+void TemporarilyEnableHotKeys(HWND hwnd) {
+    WriteLog(L"TemporarilyEnableHotKeys called.");
+
+    if (g_tempHotKeysEnabled.load()) {
+        WriteLog(L"TemporarilyEnableHotKeys already enabled. Skipping.");
+        return; // Avoid repeated enabling
+    }
+
+    g_tempHotKeysEnabled.store(true);
+
+    WinRegHandle hKey;
+    LONG result = RegOpenKeyEx(HKEY_CURRENT_USER, L"Keyboard Layout\\Toggle", 0,
+                               KEY_SET_VALUE, hKey.receive());
+    if (result == ERROR_SUCCESS) {
+        RegSetValueEx(hKey.get(), L"Language HotKey", 0, REG_SZ, reinterpret_cast<const BYTE*>(L"1"),
+                      (lstrlen(L"1") + 1) * sizeof(wchar_t));
+        RegSetValueEx(hKey.get(), L"Layout HotKey", 0, REG_SZ, reinterpret_cast<const BYTE*>(L"2"),
+                      (lstrlen(L"2") + 1) * sizeof(wchar_t));
+        WriteLog(L"Temporarily enabled hotkeys.");
+
+        // Update the global status
+        g_languageHotKeyEnabled.store(true);
+        g_layoutHotKeyEnabled.store(true);
+
+        // Update the shared memory values
+        SetLanguageHotKeyEnabled(g_languageHotKeyEnabled.load());
+        SetLayoutHotKeyEnabled(g_layoutHotKeyEnabled.load());
+
+        // Set a timer to revert changes after configured timeout
+        SetTimer(hwnd, 1, g_tempHotKeyTimeout, NULL);
+    } else {
+        WriteLog(L"Failed to open registry key for temporarily enabling hotkeys.");
+    }
+}
+
+void OnTimer(HWND hwnd) {
+    if (g_tempHotKeysEnabled.load()) {
+        ToggleLanguageHotKey(hwnd, true, false);
+        ToggleLayoutHotKey(hwnd, true, false);
+        g_tempHotKeysEnabled.store(false);
+    }
+    KillTimer(hwnd, 1);
+}

--- a/source/hotkey_registry.h
+++ b/source/hotkey_registry.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <windows.h>
+#include <atomic>
+
+// Global variables
+extern bool g_startupEnabled;
+extern std::atomic<bool> g_languageHotKeyEnabled;
+extern std::atomic<bool> g_layoutHotKeyEnabled;
+extern std::atomic<bool> g_tempHotKeysEnabled;
+extern DWORD g_tempHotKeyTimeout;
+
+// Function pointers provided by the hook DLL
+using SetLanguageHotKeyEnabledFunc = void(*)(bool);
+using SetLayoutHotKeyEnabledFunc = void(*)(bool);
+
+extern SetLanguageHotKeyEnabledFunc SetLanguageHotKeyEnabled;
+extern SetLayoutHotKeyEnabledFunc SetLayoutHotKeyEnabled;
+
+bool IsStartupEnabled();
+void AddToStartup();
+void RemoveFromStartup();
+
+bool IsLanguageHotKeyEnabled();
+bool IsLayoutHotKeyEnabled();
+
+void ToggleLanguageHotKey(HWND hwnd, bool overrideState=false, bool state=false);
+void ToggleLayoutHotKey(HWND hwnd, bool overrideState=false, bool state=false);
+void TemporarilyEnableHotKeys(HWND hwnd);
+void OnTimer(HWND hwnd);

--- a/source/tray_icon.cpp
+++ b/source/tray_icon.cpp
@@ -1,0 +1,137 @@
+#include "tray_icon.h"
+#include "res-icon.h"
+#include "hotkey_registry.h"
+#include "configuration.h"
+#include "constants.h"
+#include "log.h"
+#include "utils.h"
+
+// Global state defined elsewhere
+extern Configuration g_config;
+
+// Static tray icon data
+static NOTIFYICONDATA nid;
+
+void AddTrayIcon(HWND hwnd) {
+    if (!g_trayIconEnabled.load()) return;
+
+    ZeroMemory(&nid, sizeof(nid));
+    nid.cbSize = sizeof(NOTIFYICONDATA);
+    nid.hWnd = hwnd;
+    nid.uID = 1;
+    nid.uFlags = NIF_ICON | NIF_MESSAGE | NIF_TIP;
+    nid.uCallbackMessage = WM_TRAYICON;
+    nid.hIcon = LoadIcon(g_hInst, MAKEINTRESOURCE(IDI_MYAPP));
+    wcscpy_s(nid.szTip, ARRAYSIZE(nid.szTip), L"kbdlayoutmon");
+    Shell_NotifyIcon(NIM_ADD, &nid);
+}
+
+void RemoveTrayIcon() {
+    if (g_trayIconEnabled.load()) {
+        Shell_NotifyIcon(NIM_DELETE, &nid);
+    }
+}
+
+void ShowTrayMenu(HWND hwnd) {
+    if (!g_trayIconEnabled.load()) return;
+
+    POINT pt;
+    GetCursorPos(&pt);
+    HMENU hMenu = CreatePopupMenu();
+
+    MENUITEMINFO mii;
+    mii.cbSize = sizeof(MENUITEMINFO);
+    mii.fMask = MIIM_FTYPE | MIIM_STRING;
+    mii.fType = MFT_STRING | MFT_RIGHTJUSTIFY;
+    mii.dwTypeData = L"kbdlayoutmon";
+    InsertMenuItem(hMenu, ID_TRAY_APP_NAME, TRUE, &mii);
+    InsertMenu(hMenu, 1, MF_BYPOSITION | MF_SEPARATOR, 0, NULL);
+
+    InsertMenu(hMenu, 2, MF_BYPOSITION | MF_STRING | (g_startupEnabled ? MF_CHECKED : 0), ID_TRAY_STARTUP, L"Launch at startup");
+    InsertMenu(hMenu, 3, MF_BYPOSITION | MF_STRING | (g_languageHotKeyEnabled.load() ? MF_CHECKED : 0), ID_TRAY_TOGGLE_LANGUAGE, L"Toggle Language HotKey");
+    InsertMenu(hMenu, 4, MF_BYPOSITION | MF_STRING | (g_layoutHotKeyEnabled.load() ? MF_CHECKED : 0), ID_TRAY_TOGGLE_LAYOUT, L"Toggle Layout HotKey");
+    InsertMenu(hMenu, 5, MF_BYPOSITION | MF_STRING, ID_TRAY_TEMP_ENABLE_HOTKEYS, L"Temporarily Enable HotKeys");
+    InsertMenu(hMenu, 6, MF_BYPOSITION | MF_STRING, ID_TRAY_OPEN_LOG, L"Open Log File");
+    InsertMenu(hMenu, 7, MF_BYPOSITION | MF_STRING, ID_TRAY_OPEN_CONFIG, L"Open Config File");
+    InsertMenu(hMenu, 8, MF_BYPOSITION | MF_STRING | (g_debugEnabled.load() ? MF_CHECKED : 0), ID_TRAY_TOGGLE_DEBUG, L"Debug Logging");
+    InsertMenu(hMenu, 9, MF_BYPOSITION | MF_SEPARATOR, 0, NULL);
+    InsertMenu(hMenu, 10, MF_BYPOSITION | MF_STRING, ID_TRAY_RESTART, L"Restart");
+    InsertMenu(hMenu, 11, MF_BYPOSITION | MF_STRING, ID_TRAY_EXIT, L"Quit");
+
+    SetForegroundWindow(hwnd);
+    TrackPopupMenu(hMenu, TPM_BOTTOMALIGN | TPM_LEFTALIGN, pt.x, pt.y, 0, hwnd, NULL);
+    DestroyMenu(hMenu);
+}
+
+// Function pointers declared in main module
+extern void (*SetDebugLoggingEnabled)(bool);
+extern HMODULE g_hDll; // used for restart? not required, ignore
+
+void HandleTrayCommand(HWND hwnd, WPARAM wParam) {
+    switch (LOWORD(wParam)) {
+        case ID_TRAY_EXIT:
+            PostQuitMessage(0);
+            break;
+        case ID_TRAY_STARTUP:
+            if (g_startupEnabled) {
+                RemoveFromStartup();
+            } else {
+                AddToStartup();
+            }
+            break;
+        case ID_TRAY_TOGGLE_LANGUAGE:
+            ToggleLanguageHotKey(hwnd);
+            break;
+        case ID_TRAY_TOGGLE_LAYOUT:
+            ToggleLayoutHotKey(hwnd);
+            break;
+        case ID_TRAY_TEMP_ENABLE_HOTKEYS:
+            TemporarilyEnableHotKeys(hwnd);
+            break;
+        case ID_TRAY_OPEN_LOG:
+        {
+            wchar_t logPath[MAX_PATH] = {0};
+            auto val = g_config.get(L"log_path");
+            if (val && !val->empty()) {
+                lstrcpynW(logPath, val->c_str(), MAX_PATH);
+            } else if (g_hInst) {
+                GetModuleFileName(g_hInst, logPath, MAX_PATH);
+                PathRemoveFileSpec(logPath);
+                PathCombine(logPath, logPath, L"kbdlayoutmon.log");
+            } else {
+                lstrcpyW(logPath, L"kbdlayoutmon.log");
+            }
+            ShellExecute(NULL, L"open", logPath, NULL, NULL, SW_SHOWNORMAL);
+            break;
+        }
+        case ID_TRAY_OPEN_CONFIG:
+        {
+            wchar_t cfgPath[MAX_PATH] = {0};
+            if (g_hInst) {
+                GetModuleFileName(g_hInst, cfgPath, MAX_PATH);
+                PathRemoveFileSpec(cfgPath);
+                PathCombine(cfgPath, cfgPath, configFile.c_str());
+            } else {
+                lstrcpynW(cfgPath, configFile.c_str(), MAX_PATH);
+            }
+            ShellExecute(NULL, L"open", cfgPath, NULL, NULL, SW_SHOWNORMAL);
+            break;
+        }
+        case ID_TRAY_TOGGLE_DEBUG:
+            if (g_debugEnabled.load()) {
+                WriteLog(L"Debug logging disabled.");
+                g_debugEnabled.store(false);
+                if (SetDebugLoggingEnabled)
+                    SetDebugLoggingEnabled(false);
+            } else {
+                g_debugEnabled.store(true);
+                if (SetDebugLoggingEnabled)
+                    SetDebugLoggingEnabled(true);
+                WriteLog(L"Debug logging enabled.");
+            }
+            break;
+        case ID_TRAY_RESTART:
+            ShellExecute(NULL, L"open", L"cmd.exe", L"/C taskkill /IM kbdlayoutmon.exe /F && start kbdlayoutmon.exe", NULL, SW_HIDE);
+            break;
+    }
+}

--- a/source/tray_icon.h
+++ b/source/tray_icon.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <windows.h>
+#include <atomic>
+
+// Extern declarations for shared state
+extern HINSTANCE g_hInst;
+extern std::atomic<bool> g_trayIconEnabled;
+extern std::atomic<bool> g_debugEnabled;
+
+// Message and menu identifiers
+constexpr UINT WM_TRAYICON = WM_USER + 1;
+constexpr UINT WM_UPDATE_TRAY_MENU = WM_USER + 2;
+
+enum TrayMenuId {
+    ID_TRAY_EXIT = 1001,
+    ID_TRAY_STARTUP = 1002,
+    ID_TRAY_TOGGLE_LANGUAGE = 1003,
+    ID_TRAY_TOGGLE_LAYOUT = 1004,
+    ID_TRAY_TEMP_ENABLE_HOTKEYS = 1005,
+    ID_TRAY_APP_NAME = 1006,
+    ID_TRAY_RESTART = 1007,
+    ID_TRAY_OPEN_LOG = 1008,
+    ID_TRAY_TOGGLE_DEBUG = 1009,
+    ID_TRAY_OPEN_CONFIG = 1010
+};
+
+void AddTrayIcon(HWND hwnd);
+void RemoveTrayIcon();
+void ShowTrayMenu(HWND hwnd);
+void HandleTrayCommand(HWND hwnd, WPARAM wParam);

--- a/tests/test_hotkey_registry.cpp
+++ b/tests/test_hotkey_registry.cpp
@@ -1,0 +1,11 @@
+#include <catch2/catch_test_macros.hpp>
+#include "../source/hotkey_registry.h"
+
+TEST_CASE("Startup registry flag toggles") {
+    g_startupEnabled = false;
+    AddToStartup();
+    REQUIRE(g_startupEnabled);
+    RemoveFromStartup();
+    REQUIRE_FALSE(g_startupEnabled);
+}
+

--- a/tests/windows.h
+++ b/tests/windows.h
@@ -19,6 +19,8 @@ using BYTE = unsigned char;
 using LONG = long;
 using HOOKPROC = LRESULT(*)(int, WPARAM, LPARAM);
 using LPVOID = void*;
+using UINT = unsigned int;
+using LPBYTE = BYTE*;
 
 #define TRUE 1
 #define FALSE 0
@@ -33,6 +35,7 @@ using LPVOID = void*;
 #define ERROR_SUCCESS 0L
 #define REG_SZ 1
 #define KEY_SET_VALUE 0x0002
+#define KEY_READ 0x20019
 #define GENERIC_WRITE 0x40000000
 #define OPEN_EXISTING 3
 #define FILE_ATTRIBUTE_NORMAL 0x80
@@ -77,6 +80,21 @@ inline HANDLE CreateFileW(LPCWSTR, DWORD, DWORD, void*, DWORD, DWORD, HANDLE) { 
 inline BOOL WriteFile(HANDLE, const void*, DWORD, DWORD*, void*) { return TRUE; }
 inline LONG RegOpenKeyEx(HKEY, LPCWSTR, DWORD, DWORD, HKEY*) { return ERROR_SUCCESS; }
 inline LONG RegSetValueEx(HKEY, LPCWSTR, DWORD, DWORD, const BYTE*, DWORD) { return ERROR_SUCCESS; }
+inline LONG RegSetValueExW(HKEY, LPCWSTR, DWORD, DWORD, const BYTE*, DWORD) { return ERROR_SUCCESS; }
+inline LONG RegQueryValueEx(HKEY, LPCWSTR valueName, DWORD, DWORD*, BYTE* data, DWORD* len) {
+    if (valueName && data && len && *len >= sizeof(wchar_t) * 2) {
+        auto wdata = reinterpret_cast<wchar_t*>(data);
+        if (wcscmp(valueName, L"Language HotKey") == 0) {
+            wcscpy(wdata, L"1");
+        } else if (wcscmp(valueName, L"Layout HotKey") == 0) {
+            wcscpy(wdata, L"2");
+        } else {
+            wdata[0] = L'\0';
+        }
+    }
+    return ERROR_SUCCESS;
+}
+inline LONG RegDeleteValue(HKEY, LPCWSTR) { return ERROR_SUCCESS; }
 inline LONG RegCloseKey(HKEY) { return ERROR_SUCCESS; }
 inline HKL GetKeyboardLayout(DWORD) { return nullptr; }
 inline BOOL GetKeyboardLayoutName(wchar_t*) { return TRUE; }
@@ -88,3 +106,6 @@ inline HANDLE CreateMutex(void*, BOOL, LPCWSTR) { return nullptr; }
 inline DWORD WaitForSingleObject(HANDLE, DWORD) { return WAIT_OBJECT_0; }
 inline BOOL ReleaseMutex(HANDLE) { return TRUE; }
 inline void DisableThreadLibraryCalls(HINSTANCE) {}
+inline UINT SetTimer(HWND, UINT, UINT, void*) { return 1; }
+inline BOOL KillTimer(HWND, UINT) { return TRUE; }
+inline int lstrlen(const wchar_t* s) { return wcslen(s); }


### PR DESCRIPTION
## Summary
- extract tray icon and menu handling into dedicated module
- move startup and hotkey registry utilities into hotkey_registry
- streamline main window proc logic and add basic integration test

## Testing
- `cmake --build .`
- `ctest -V`


------
https://chatgpt.com/codex/tasks/task_e_68a266977e6883258ca9e49a931e0208