### PR TITLE
Move debug logging toggle to log module

### DIFF
--- a/source/kbdlayoutmonhook.cpp
+++ b/source/kbdlayoutmonhook.cpp
@@ -331,14 +331,6 @@ extern "C" __declspec(dllexport) void SetLayoutHotKeyEnabled(bool enabled) {
 }
 
 /**
- * @brief Update debug logging state for the DLL.
- * @param enabled When true, log messages are written.
- */
-extern "C" __declspec(dllexport) void SetDebugLoggingEnabled(bool enabled) {
-    g_debugEnabled.store(enabled);
-}
-
-/**
  * @brief Standard DLL entry point called by the loader.
  */
 BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved) {

--- a/source/log.cpp
+++ b/source/log.cpp
@@ -21,7 +21,6 @@ inline void lstrcpyW(wchar_t* dst, const wchar_t* src) { std::wcscpy(dst, src); 
 #include "configuration.h"
 
 extern HINSTANCE g_hInst; // Provided by the executable or DLL
-extern std::atomic<bool> g_debugEnabled;
 std::atomic<bool> g_verboseLogging{false};
 
 namespace {
@@ -51,6 +50,11 @@ std::wstring GetLogPath() {
 
 /// Global log instance used by the executable and DLL.
 Log g_log;
+
+extern std::atomic<bool> g_debugEnabled;
+extern "C" void SetDebugLoggingEnabled(bool enabled) {
+    g_debugEnabled.store(enabled);
+}
 
 extern "C" void WriteLog(const wchar_t* message) {
     g_log.write(message);


### PR DESCRIPTION
## Summary
- export a new `SetDebugLoggingEnabled` function from `log.cpp`
- remove duplicate `SetDebugLoggingEnabled` definition from hook library

## Testing
- `cmake --build build`
- `ctest`
- `nm -C build/CMakeFiles/run_tests.dir/source/log.cpp.o | grep SetDebugLoggingEnabled`


------
https://chatgpt.com/codex/tasks/task_e_68a26ef1ca4483259d87e308f0989200