### PR TITLE
Use RAII for tray icon

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -7,8 +7,8 @@ if ! echo '#include <catch2/catch_test_macros.hpp>' | g++ -std=c++17 -x c++ - -f
     exit 1
 fi
 
-g++ -std=c++17 -I tests \
-    tests/test_configuration.cpp tests/test_log.cpp tests/test_utils.cpp tests/test_timer_guard.cpp \
-    source/configuration.cpp source/log.cpp source/config_parser.cpp -o tests/run_tests \
+g++ -std=c++17 -DUNIT_TEST -I tests -I resources \
+    tests/test_configuration.cpp tests/test_log.cpp tests/test_utils.cpp tests/test_timer_guard.cpp tests/test_tray_icon.cpp \
+    source/configuration.cpp source/log.cpp source/config_parser.cpp source/tray_icon.cpp -o tests/run_tests \
     -lCatch2Main -lCatch2 -pthread
 ./tests/run_tests

--- a/source/tray_icon.h
+++ b/source/tray_icon.h
@@ -24,7 +24,19 @@ enum TrayMenuId {
     ID_TRAY_OPEN_CONFIG = 1010
 };
 
-void AddTrayIcon(HWND hwnd);
-void RemoveTrayIcon();
+class TrayIcon {
+public:
+    explicit TrayIcon(HWND hwnd);
+    ~TrayIcon();
+
+    TrayIcon(const TrayIcon&) = delete;
+    TrayIcon& operator=(const TrayIcon&) = delete;
+
+private:
+    bool added_ = false;
+};
+
+extern BOOL (WINAPI *pShell_NotifyIcon)(DWORD, PNOTIFYICONDATA);
+
 void ShowTrayMenu(HWND hwnd);
 void HandleTrayCommand(HWND hwnd, WPARAM wParam);

--- a/tests/test_tray_icon.cpp
+++ b/tests/test_tray_icon.cpp
@@ -1,0 +1,33 @@
+#include <catch2/catch_test_macros.hpp>
+#include "../source/tray_icon.h"
+#include <set>
+#include <stdexcept>
+#include <atomic>
+
+// Provide definitions for globals expected by tray_icon
+HINSTANCE g_hInst = nullptr;
+std::atomic<bool> g_trayIconEnabled{true};
+
+// Track icon IDs added and removed
+static std::set<UINT> g_icons;
+
+BOOL FakeShellNotifyIcon(DWORD msg, PNOTIFYICONDATA data) {
+    if (msg == NIM_ADD) {
+        g_icons.insert(data->uID);
+    } else if (msg == NIM_DELETE) {
+        g_icons.erase(data->uID);
+    }
+    return TRUE;
+}
+
+TEST_CASE("TrayIcon removes icon on destruction during exception") {
+    g_icons.clear();
+    pShell_NotifyIcon = FakeShellNotifyIcon;
+    try {
+        TrayIcon icon(reinterpret_cast<HWND>(1));
+        throw std::runtime_error("boom");
+    } catch (const std::exception&) {
+        // swallow
+    }
+    REQUIRE(g_icons.empty());
+}

--- a/tests/windows.h
+++ b/tests/windows.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <cstdint>
 #include <cwchar>
+#include <cstring>
 
 using HANDLE = void*;
 using HINSTANCE = void*;
@@ -40,6 +41,16 @@ using LPBYTE = BYTE*;
 #define GENERIC_WRITE 0x40000000
 #define OPEN_EXISTING 3
 #define FILE_ATTRIBUTE_NORMAL 0x80
+#define WM_USER 0x0400
+#define NIF_MESSAGE 0x00000001
+#define NIF_ICON 0x00000002
+#define NIF_TIP 0x00000004
+#define NIM_ADD 0x00000000
+#define NIM_DELETE 0x00000002
+#ifndef ARRAYSIZE
+#define ARRAYSIZE(A) (sizeof(A) / sizeof((A)[0]))
+#endif
+#define HWND_MESSAGE ((HWND)-3)
 #define HKEY_CURRENT_USER ((HKEY)1)
 #define HKEY_USERS ((HKEY)2)
 #define LOWORD(l) ((LANGID)((uintptr_t)(l) & 0xFFFF))
@@ -68,6 +79,26 @@ extern "C" {
     extern DWORD (*pWaitForMultipleObjects)(DWORD, const HANDLE*, BOOL, DWORD);
     extern DWORD (*pGetModuleFileNameW)(HINSTANCE, wchar_t*, DWORD);
 }
+
+struct NOTIFYICONDATA {
+    DWORD cbSize;
+    HWND hWnd;
+    UINT uID;
+    UINT uFlags;
+    UINT uCallbackMessage;
+    HANDLE hIcon;
+    wchar_t szTip[64];
+};
+
+using PNOTIFYICONDATA = NOTIFYICONDATA*;
+
+inline BOOL Shell_NotifyIcon(DWORD, NOTIFYICONDATA*) { return TRUE; }
+#define ZeroMemory(ptr, size) std::memset(ptr, 0, size)
+#ifndef MAKEINTRESOURCE
+#define MAKEINTRESOURCE(i) ((LPCWSTR)(uintptr_t)((uint16_t)(i)))
+#endif
+inline HANDLE LoadIcon(HINSTANCE, LPCWSTR) { return nullptr; }
+inline int wcscpy_s(wchar_t* dst, size_t, const wchar_t* src) { std::wcscpy(dst, src); return 0; }
 
 inline HANDLE CreateEventW(void* a, BOOL b, BOOL c, LPCWSTR d) { return pCreateEventW(a,b,c,d); }
 inline BOOL SetEvent(HANDLE h) { return pSetEvent(h); }


### PR DESCRIPTION
## Summary
- Replace manual tray icon management with RAII `TrayIcon` class
- Ensure tray icon cleaned up on abnormal exits
- Add tests verifying tray icon removal even on early termination

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a614cfcdf08325b69160a0001e2284