### PR TITLE
Use ReadDirectoryChangesW for configuration reloads

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -8,7 +8,7 @@ if ! echo '#include <catch2/catch_test_macros.hpp>' | g++ -std=c++17 -x c++ - -f
 fi
 
 g++ -std=c++17 -DUNIT_TEST -I tests -I resources \
-    tests/test_configuration.cpp tests/test_log.cpp tests/test_utils.cpp tests/test_timer_guard.cpp tests/test_tray_icon.cpp tests/test_tray_icon_integration.cpp \
-    source/configuration.cpp source/log.cpp source/config_parser.cpp source/tray_icon.cpp -o tests/run_tests \
+    tests/test_configuration.cpp tests/test_log.cpp tests/test_utils.cpp tests/test_timer_guard.cpp tests/test_tray_icon.cpp tests/test_tray_icon_integration.cpp tests/test_config_watcher.cpp \
+    source/configuration.cpp source/log.cpp source/config_parser.cpp source/tray_icon.cpp source/config_watcher.cpp -o tests/run_tests \
     -lCatch2Main -lCatch2 -pthread
 ./tests/run_tests

--- a/source/config_watcher.cpp
+++ b/source/config_watcher.cpp
@@ -43,30 +43,83 @@ void ConfigWatcher::threadProc(ConfigWatcher* self) {
     }
     PathRemoveFileSpecW(dirPath);
 
-    HandleGuard hChange(FindFirstChangeNotificationW(dirPath, FALSE, FILE_NOTIFY_CHANGE_LAST_WRITE));
-    if (!hChange)
-        return;
-
-    HANDLE handles[2] = { hChange.get(), self->m_stopEvent.get() };
+    // Continuously attempt to monitor the directory until the stop event is signalled.
     for (;;) {
-        DWORD wait = WaitForMultipleObjects(2, handles, FALSE, INFINITE);
-        if (wait == WAIT_OBJECT_0) {
+        HandleGuard hDir(CreateFileW(
+            dirPath, FILE_LIST_DIRECTORY,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            NULL, OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED, NULL));
+
+        if (!hDir) {
+            WriteLog(L"CreateFileW failed for configuration directory.");
+            continue;
+        }
+
+        BYTE buffer[1024];
+        OVERLAPPED ov{};
+        HandleGuard hEvent(CreateEventW(NULL, FALSE, FALSE, NULL));
+        if (!hEvent) {
+            WriteLog(L"Failed to create directory watch event.");
+            break;
+        }
+        ov.hEvent = hEvent.get();
+
+        HANDLE handles[2] = { hEvent.get(), self->m_stopEvent.get() };
+        bool restart = false;
+        while (!restart) {
+            DWORD bytesReturned = 0;
+            BOOL ok = ReadDirectoryChangesW(
+                hDir.get(), buffer, sizeof(buffer), FALSE,
+                FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_LAST_WRITE,
+                &bytesReturned, &ov, NULL);
+
+            if (!ok) {
+                WriteLog(L"ReadDirectoryChangesW failed.");
+                restart = true;
+                break;
+            }
+
+            DWORD wait = WaitForMultipleObjects(2, handles, FALSE, INFINITE);
+            if (wait == WAIT_OBJECT_0 + 1) {
+                CancelIoEx(hDir.get(), &ov);
+                WaitForSingleObject(hEvent.get(), INFINITE);
+                return;
+            }
+            if (wait != WAIT_OBJECT_0) {
+                WriteLog(L"WaitForMultipleObjects failed.");
+                restart = true;
+                break;
+            }
+
+            bytesReturned = 0;
+            if (!GetOverlappedResult(hDir.get(), &ov, &bytesReturned, FALSE)) {
+                WriteLog(L"GetOverlappedResult failed.");
+                restart = true;
+                break;
+            }
+
+            bool renamed = false;
+            BYTE* ptr = buffer;
+            while (bytesReturned > 0) {
+                auto* info = reinterpret_cast<FILE_NOTIFY_INFORMATION*>(ptr);
+                if (info->Action == FILE_ACTION_RENAMED_OLD_NAME ||
+                    info->Action == FILE_ACTION_RENAMED_NEW_NAME) {
+                    renamed = true;
+                }
+                if (info->NextEntryOffset == 0)
+                    break;
+                bytesReturned -= info->NextEntryOffset;
+                ptr += info->NextEntryOffset;
+            }
+
             g_config.load();
             ApplyConfig(self->m_hwnd);
             WriteLog(L"Configuration reloaded.");
-            BOOL ok = FindNextChangeNotification(hChange.get());
-            if (!ok) {
-                WriteLog(L"FindNextChangeNotification failed.");
-                break;
-            }
-        } else if (wait == WAIT_OBJECT_0 + 1) {
-            break;
-        } else {
-            break;
+
+            if (renamed)
+                restart = true;
         }
     }
-
-    FindCloseChangeNotification(hChange.release());
-    return;
 }
 

--- a/tests/test_config_watcher.cpp
+++ b/tests/test_config_watcher.cpp
@@ -1,30 +1,49 @@
 #include <catch2/catch_test_macros.hpp>
 #include <thread>
 #include <chrono>
+#include <filesystem>
+#include <cstring>
 
 #define private public
 #include "../source/config_watcher.h"
 #undef private
 
 extern HINSTANCE g_hInst;
-void ApplyConfig(HWND) {}
+static int applyCalls = 0;
+void ApplyConfig(HWND) { ++applyCalls; }
 
 HANDLE (*pCreateEventW)(void*, BOOL, BOOL, LPCWSTR) = [](void*, BOOL, BOOL, LPCWSTR){ return reinterpret_cast<HANDLE>(1); };
 BOOL (*pSetEvent)(HANDLE) = [](HANDLE){ return TRUE; };
-HANDLE (*pFindFirstChangeNotificationW)(LPCWSTR, BOOL, DWORD) = [](LPCWSTR, BOOL, DWORD){ return reinterpret_cast<HANDLE>(1); };
-static int nextCalls = 0;
-BOOL (*pFindNextChangeNotification)(HANDLE) = [](HANDLE){ ++nextCalls; return FALSE; };
-static int closeCalls = 0;
-BOOL (*pFindCloseChangeNotification)(HANDLE) = [](HANDLE){ ++closeCalls; return TRUE; };
-DWORD (*pWaitForMultipleObjects)(DWORD, const HANDLE*, BOOL, DWORD) = [](DWORD, const HANDLE*, BOOL, DWORD) -> DWORD { return WAIT_OBJECT_0; };
+HANDLE (*pCreateFileW)(LPCWSTR, DWORD, DWORD, void*, DWORD, DWORD, HANDLE) = [](LPCWSTR, DWORD, DWORD, void*, DWORD, DWORD, HANDLE){ return reinterpret_cast<HANDLE>(1); };
+static DWORD lastBytes = 0;
+BOOL (*pReadDirectoryChangesW)(HANDLE, void* buffer, DWORD, BOOL, DWORD, DWORD* bytesReturned, OVERLAPPED*, void*) = [](HANDLE, void* buffer, DWORD, BOOL, DWORD, DWORD* bytesReturned, OVERLAPPED*, void*) {
+    auto* info = reinterpret_cast<FILE_NOTIFY_INFORMATION*>(buffer);
+    info->NextEntryOffset = 0;
+    info->Action = FILE_ACTION_RENAMED_NEW_NAME;
+    const wchar_t* name = L"kbdlayoutmon.config";
+    info->FileNameLength = static_cast<DWORD>(wcslen(name) * sizeof(wchar_t));
+    std::memcpy(info->FileName, name, info->FileNameLength);
+    lastBytes = sizeof(FILE_NOTIFY_INFORMATION) + info->FileNameLength;
+    if (bytesReturned) *bytesReturned = lastBytes;
+    return TRUE;
+};
+BOOL (*pCancelIoEx)(HANDLE, OVERLAPPED*) = [](HANDLE, OVERLAPPED*) { return TRUE; };
+BOOL (*pGetOverlappedResult)(HANDLE, OVERLAPPED*, DWORD* bytes, BOOL) = [](HANDLE, OVERLAPPED*, DWORD* bytes, BOOL){ if(bytes) *bytes = lastBytes; return TRUE; };
+static int waitCalls = 0;
+DWORD (*pWaitForMultipleObjects)(DWORD, const HANDLE*, BOOL, DWORD) = [](DWORD, const HANDLE*, BOOL, DWORD) -> DWORD {
+    return waitCalls++ == 0 ? WAIT_OBJECT_0 : WAIT_OBJECT_0 + 1;
+};
 DWORD (*pGetModuleFileNameW)(HINSTANCE, wchar_t* buffer, DWORD) = [](HINSTANCE, wchar_t* buffer, DWORD) -> DWORD { buffer[0] = L'\0'; return 0; };
 
-TEST_CASE("Watcher exits when FindNextChangeNotification fails", "[config_watcher]") {
+TEST_CASE("Renaming config file triggers reload", "[config_watcher]") {
+    applyCalls = 0;
     {
         ConfigWatcher watcher(nullptr);
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        std::filesystem::rename("kbdlayoutmon.config", "kbdlayoutmon.config.tmp");
+        std::filesystem::rename("kbdlayoutmon.config.tmp", "kbdlayoutmon.config");
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
-    REQUIRE(nextCalls == 1);
-    REQUIRE(closeCalls == 1);
+    REQUIRE(applyCalls >= 1);
 }
 

--- a/tests/test_log.cpp
+++ b/tests/test_log.cpp
@@ -11,7 +11,7 @@ using HINSTANCE = void*;
 #endif
 
 extern HINSTANCE g_hInst;
-extern std::atomic<bool> g_debugEnabled;
+std::atomic<bool> g_debugEnabled{false};
 
 TEST_CASE("Log switches files when path changes", "[log]") {
     g_debugEnabled.store(true);


### PR DESCRIPTION
## Summary
- Watch configuration directory with `ReadDirectoryChangesW` to handle file writes and renames
- Improve error handling and restart logic for config watcher
- Add test verifying config reload on file rename

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a75650dec48325b4c9504a71291093