### PR TITLE
Handle stop event when directory open fails

### DIFF
--- a/source/config_watcher.cpp
+++ b/source/config_watcher.cpp
@@ -53,6 +53,9 @@ void ConfigWatcher::threadProc(ConfigWatcher* self) {
 
         if (!hDir) {
             WriteLog(L"CreateFileW failed for configuration directory.");
+            if (WaitForSingleObject(self->m_stopEvent.get(), 0) == WAIT_OBJECT_0)
+                break;
+            Sleep(100);
             continue;
         }
 

--- a/tests/test_config_watcher.cpp
+++ b/tests/test_config_watcher.cpp
@@ -11,10 +11,17 @@
 extern HINSTANCE g_hInst;
 static int applyCalls = 0;
 void ApplyConfig(HWND) { ++applyCalls; }
-
-HANDLE (*pCreateEventW)(void*, BOOL, BOOL, LPCWSTR) = [](void*, BOOL, BOOL, LPCWSTR){ return reinterpret_cast<HANDLE>(1); };
-BOOL (*pSetEvent)(HANDLE) = [](HANDLE){ return TRUE; };
+static HANDLE g_stopHandle = nullptr;
+static bool stopSignaled = false;
+HANDLE (*pCreateEventW)(void*, BOOL, BOOL, LPCWSTR) = [](void*, BOOL, BOOL, LPCWSTR){
+    static intptr_t next = 1;
+    return reinterpret_cast<HANDLE>(next++);
+};
+BOOL (*pSetEvent)(HANDLE h) = [](HANDLE h){ if (h == g_stopHandle) stopSignaled = true; return TRUE; };
 HANDLE (*pCreateFileW)(LPCWSTR, DWORD, DWORD, void*, DWORD, DWORD, HANDLE) = [](LPCWSTR, DWORD, DWORD, void*, DWORD, DWORD, HANDLE){ return reinterpret_cast<HANDLE>(1); };
+DWORD (*pWaitForSingleObject)(HANDLE, DWORD) = [](HANDLE h, DWORD) -> DWORD {
+    return (h == g_stopHandle && !stopSignaled) ? WAIT_TIMEOUT : WAIT_OBJECT_0;
+};
 static DWORD lastBytes = 0;
 BOOL (*pReadDirectoryChangesW)(HANDLE, void* buffer, DWORD, BOOL, DWORD, DWORD* bytesReturned, OVERLAPPED*, void*) = [](HANDLE, void* buffer, DWORD, BOOL, DWORD, DWORD* bytesReturned, OVERLAPPED*, void*) {
     auto* info = reinterpret_cast<FILE_NOTIFY_INFORMATION*>(buffer);
@@ -45,5 +52,26 @@ TEST_CASE("Renaming config file triggers reload", "[config_watcher]") {
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
     REQUIRE(applyCalls >= 1);
+}
+
+TEST_CASE("Watcher exits when stop event set and directory cannot be opened", "[config_watcher]") {
+    auto origCreateFileW = pCreateFileW;
+    pCreateFileW = [](LPCWSTR, DWORD, DWORD, void*, DWORD, DWORD, HANDLE) -> HANDLE { return nullptr; };
+
+    stopSignaled = false;
+    waitCalls = 0;
+    std::chrono::steady_clock::time_point start;
+    {
+        ConfigWatcher watcher(nullptr);
+        g_stopHandle = watcher.m_stopEvent.get();
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        SetEvent(g_stopHandle);
+        start = std::chrono::steady_clock::now();
+    }
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    pCreateFileW = origCreateFileW;
+    g_stopHandle = nullptr;
+    stopSignaled = false;
+    REQUIRE(elapsed < std::chrono::milliseconds(50));
 }
 

--- a/tests/windows.h
+++ b/tests/windows.h
@@ -83,6 +83,7 @@ struct FILE_NOTIFY_INFORMATION {
 #define TRUE 1
 #define FALSE 0
 #define WAIT_OBJECT_0 0
+#define WAIT_TIMEOUT 258
 #define INFINITE 0xFFFFFFFF
 #define MAX_PATH 260
 #define FILE_NOTIFY_CHANGE_LAST_WRITE 0x00000010
@@ -224,7 +225,8 @@ inline LRESULT CallNextHookEx(HHOOK, int, WPARAM, LPARAM) { return 0; }
 inline BOOL UnhookWindowsHookEx(HHOOK) { return TRUE; }
 inline DWORD GetLastError() { return 0; }
 inline HANDLE CreateMutex(void*, BOOL, LPCWSTR) { return nullptr; }
-inline DWORD WaitForSingleObject(HANDLE, DWORD) { return WAIT_OBJECT_0; }
+extern DWORD (*pWaitForSingleObject)(HANDLE, DWORD);
+inline DWORD WaitForSingleObject(HANDLE a, DWORD b) { return pWaitForSingleObject(a, b); }
 inline BOOL ReleaseMutex(HANDLE) { return TRUE; }
 inline void DisableThreadLibraryCalls(HINSTANCE) {}
 extern UINT (*pSetTimer)(HWND, UINT, UINT, TIMERPROC);
@@ -232,3 +234,4 @@ extern BOOL (*pKillTimer)(HWND, UINT);
 inline UINT SetTimer(HWND a, UINT b, UINT c, TIMERPROC d) { return pSetTimer(a, b, c, d); }
 inline BOOL KillTimer(HWND a, UINT b) { return pKillTimer(a, b); }
 inline int lstrlen(const wchar_t* s) { return wcslen(s); }
+inline void Sleep(DWORD) {}


### PR DESCRIPTION
## Summary
- Break out of config watcher retry loop when stop event is signaled and directory handle can't be opened
- Pause briefly before retrying directory monitoring
- Add unit test verifying watcher exits when stop event is set and directory open fails

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a8bb14327c8325b6f59f0de00d81f4