### PR TITLE
Handle stop event when directory open fails with backoff

### DIFF
--- a/tests/windows.h
+++ b/tests/windows.h
@@ -234,4 +234,5 @@ extern BOOL (*pKillTimer)(HWND, UINT);
 inline UINT SetTimer(HWND a, UINT b, UINT c, TIMERPROC d) { return pSetTimer(a, b, c, d); }
 inline BOOL KillTimer(HWND a, UINT b) { return pKillTimer(a, b); }
 inline int lstrlen(const wchar_t* s) { return wcslen(s); }
-inline void Sleep(DWORD) {}
+extern int g_sleepCalls;
+inline void Sleep(DWORD) { ++g_sleepCalls; }


### PR DESCRIPTION
## Summary
- Add exponential backoff and stop-event check when configuration directory fails to open
- Track Sleep calls in test shim
- Add unit test ensuring watcher exits quickly when stop event is set during directory open failures

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a8d078a6ac8325be6ac795aa5b83af