### PR TITLE
Add CLI flags for startup and hotkey control

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,8 +51,26 @@ configuration file. Use `--help` to display a summary at runtime:
 --log-path <path>         Override log file location
 --max-log-size-mb <num>   Override maximum log size
 --max-queue-size <num>    Override maximum queued log messages
+--enable-startup          Add the application to user startup
+--disable-startup         Remove the application from user startup
+--enable-language-hotkey  Enable the Windows "Language" hotkey
+--disable-layout-hotkey   Disable the Windows "Layout" hotkey
 --version                 Print the application version and exit
 --help                    Show this help text
+```
+
+### Examples
+
+Enable startup launch and the language hotkey:
+
+```bash
+kbdlayoutmon --enable-startup --enable-language-hotkey
+```
+
+Disable startup launch and the layout hotkey:
+
+```bash
+kbdlayoutmon --disable-startup --disable-layout-hotkey
 ```
 
 ## Build

--- a/source/kbdlayoutmon.cpp
+++ b/source/kbdlayoutmon.cpp
@@ -94,6 +94,10 @@ std::wstring GetUsageString() {
         L"  --log-path <path>          Override log file location\n"
         L"  --max-log-size-mb <num>    Override max log size\n"
         L"  --max-queue-size <num>     Override log queue length\n"
+        L"  --enable-startup           Add application to user startup\n"
+        L"  --disable-startup          Remove application from user startup\n"
+        L"  --enable-language-hotkey   Enable the Windows \"Language\" hotkey\n"
+        L"  --disable-layout-hotkey    Disable the Windows \"Layout\" hotkey\n"
         L"  --version    Print the application version and exit\n"
         L"  --help       Show this help message and exit";
 }
@@ -248,6 +252,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
             } else if (wcscmp(argv[i], L"--max-queue-size") == 0 && i + 1 < argc) {
                 g_config.set(L"max_queue_size", argv[i + 1]);
                 ++i;
+            } else if (wcscmp(argv[i], L"--enable-startup") == 0) {
+                AddToStartup();
+            } else if (wcscmp(argv[i], L"--disable-startup") == 0) {
+                RemoveFromStartup();
+            } else if (wcscmp(argv[i], L"--enable-language-hotkey") == 0) {
+                ToggleLanguageHotKey(nullptr, true, true);
+            } else if (wcscmp(argv[i], L"--disable-layout-hotkey") == 0) {
+                ToggleLayoutHotKey(nullptr, true, false);
             } else if (wcscmp(argv[i], L"--cli") == 0 || wcscmp(argv[i], L"--cli-mode") == 0) {
                 g_cliMode = true;
                 g_trayIconEnabled.store(false);


### PR DESCRIPTION
## Summary
- document and parse `--enable-startup`, `--disable-startup`, `--enable-language-hotkey`, `--disable-layout-hotkey`
- update README with usage examples for the new flags

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a9eee2588483259182fe6311001a99