### PR TITLE
Add log levels to logging system

### DIFF
--- a/source/configuration.cpp
+++ b/source/configuration.cpp
@@ -45,7 +45,7 @@ void Configuration::load(std::optional<std::wstring> path) {
 #endif
     if (!file.is_open()) {
         std::wstring msg = L"Failed to open configuration file: " + fullPath;
-        WriteLog(msg.c_str());
+        WriteLog(LogLevel::Error, msg.c_str());
         return;
     }
 

--- a/source/hotkey_registry.cpp
+++ b/source/hotkey_registry.cpp
@@ -46,10 +46,10 @@ void AddToStartup() {
         RegSetValueExW(hKey.get(), L"kbdlayoutmon", 0, REG_SZ,
                        reinterpret_cast<const BYTE*>(quotedPath.c_str()),
                        (quotedPath.size() + 1) * sizeof(wchar_t));
-        WriteLog(L"Added to startup.");
+        WriteLog(LogLevel::Info, L"Added to startup.");
         g_startupEnabled = true;
     } else {
-        WriteLog(L"Failed to add to startup.");
+        WriteLog(LogLevel::Error, L"Failed to add to startup.");
     }
 }
 
@@ -61,10 +61,10 @@ void RemoveFromStartup() {
                                0, KEY_SET_VALUE, hKey.receive());
     if (result == ERROR_SUCCESS) {
         RegDeleteValue(hKey.get(), L"kbdlayoutmon");
-        WriteLog(L"Removed from startup.");
+        WriteLog(LogLevel::Info, L"Removed from startup.");
         g_startupEnabled = false;
     } else {
-        WriteLog(L"Failed to remove from startup.");
+        WriteLog(LogLevel::Error, L"Failed to remove from startup.");
     }
 }
 
@@ -80,10 +80,10 @@ bool IsLanguageHotKeyEnabled() {
                                  (LPBYTE)value, &value_length);
         std::wstringstream ss;
         ss << L"Language HotKey value: " << value;
-        WriteLog(ss.str().c_str());
+        WriteLog(LogLevel::Info, ss.str().c_str());
         return (result == ERROR_SUCCESS && wcscmp(value, L"3") == 0);
     } else {
-        WriteLog(L"Failed to open registry key for Language HotKey.");
+        WriteLog(LogLevel::Error, L"Failed to open registry key for Language HotKey.");
     }
     return false;
 }
@@ -100,10 +100,10 @@ bool IsLayoutHotKeyEnabled() {
                                  (LPBYTE)value, &value_length);
         std::wstringstream ss;
         ss << L"Layout HotKey value: " << value;
-        WriteLog(ss.str().c_str());
+        WriteLog(LogLevel::Info, ss.str().c_str());
         return (result == ERROR_SUCCESS && wcscmp(value, L"3") == 0);
     } else {
-        WriteLog(L"Failed to open registry key for Layout HotKey.");
+        WriteLog(LogLevel::Error, L"Failed to open registry key for Layout HotKey.");
     }
     return false;
 }
@@ -136,7 +136,7 @@ static void ToggleHotKey(HWND hwnd, const wchar_t* valueName,
             std::wstringstream ss;
             ss << L"Failed to set registry value for " << valueName
                << L". Error: " << result;
-            WriteLog(ss.str().c_str());
+            WriteLog(LogLevel::Error, ss.str().c_str());
             enabledFlag.store(previous);
             return;
         }
@@ -161,10 +161,10 @@ void ToggleLayoutHotKey(HWND hwnd, bool overrideState, bool state) {
 }
 
 void TemporarilyEnableHotKeys(HWND hwnd) {
-    WriteLog(L"TemporarilyEnableHotKeys called.");
+    WriteLog(LogLevel::Info, L"TemporarilyEnableHotKeys called.");
 
     if (g_tempHotKeysEnabled.load()) {
-        WriteLog(L"TemporarilyEnableHotKeys already enabled. Skipping.");
+        WriteLog(LogLevel::Warn, L"TemporarilyEnableHotKeys already enabled. Skipping.");
         return; // Avoid repeated enabling
     }
 
@@ -178,7 +178,7 @@ void TemporarilyEnableHotKeys(HWND hwnd) {
         if (result != ERROR_SUCCESS) {
             std::wstringstream ss;
             ss << L"Failed to set Language HotKey. Error: " << result;
-            WriteLog(ss.str().c_str());
+            WriteLog(LogLevel::Error, ss.str().c_str());
             return;
         }
 
@@ -188,11 +188,11 @@ void TemporarilyEnableHotKeys(HWND hwnd) {
         if (result != ERROR_SUCCESS) {
             std::wstringstream ss;
             ss << L"Failed to set Layout HotKey. Error: " << result;
-            WriteLog(ss.str().c_str());
+            WriteLog(LogLevel::Error, ss.str().c_str());
             return;
         }
 
-        WriteLog(L"Temporarily enabled hotkeys.");
+        WriteLog(LogLevel::Info, L"Temporarily enabled hotkeys.");
 
         g_tempHotKeysEnabled.store(true);
 
@@ -210,13 +210,13 @@ void TemporarilyEnableHotKeys(HWND hwnd) {
         if (*timer) {
             g_tempHotKeyTimer = std::move(timer);
         } else {
-            WriteLog(L"Failed to set timer for temporarily enabling hotkeys.");
+            WriteLog(LogLevel::Error, L"Failed to set timer for temporarily enabling hotkeys.");
             ToggleLanguageHotKey(hwnd, true, false);
             ToggleLayoutHotKey(hwnd, true, false);
             g_tempHotKeysEnabled.store(false);
         }
     } else {
-        WriteLog(L"Failed to open registry key for temporarily enabling hotkeys.");
+        WriteLog(LogLevel::Error, L"Failed to open registry key for temporarily enabling hotkeys.");
     }
 }
 

--- a/source/kbdlayoutmon.cpp
+++ b/source/kbdlayoutmon.cpp
@@ -207,7 +207,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     // Create a named mutex to ensure a single instance
     g_hInstanceMutex.reset(CreateMutex(NULL, TRUE, L"InputMethodMonitorSingleton"));
     if (g_hInstanceMutex && GetLastError() == ERROR_ALREADY_EXISTS) {
-        WriteLog(L"Another instance is already running.");
+        WriteLog(LogLevel::Error, L"Another instance is already running.");
         if (g_cliMode || AttachConsole(ATTACH_PARENT_PROCESS)) {
             FILE* fp = _wfopen(L"CONOUT$", L"w");
             if (fp) {
@@ -326,7 +326,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         LocalFree(argv);
     }
 
-    WriteLog(L"Executable started.");
+    WriteLog(LogLevel::Info, L"Executable started.");
 
     // Check if the app is set to launch at startup
     g_startupEnabled = IsStartupEnabled();
@@ -348,7 +348,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         DWORD errorCode = GetLastError();
         std::wstringstream ss;
         ss << L"Failed to register window class. Error code: 0x" << std::hex << errorCode;
-        WriteLog(ss.str());
+        WriteLog(LogLevel::Error, ss.str());
         if (g_hInstanceMutex) {
             ReleaseMutex(g_hInstanceMutex.get());
             g_hInstanceMutex.reset();
@@ -373,7 +373,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         DWORD errorCode = GetLastError();
         std::wstringstream ss;
         ss << L"Failed to create message-only window. Error code: 0x" << std::hex << errorCode;
-        WriteLog(ss.str());
+        WriteLog(LogLevel::Error, ss.str());
         if (g_hInstanceMutex) {
             ReleaseMutex(g_hInstanceMutex.get());
             g_hInstanceMutex.reset();
@@ -401,7 +401,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
             DWORD errorCode = GetLastError();
             std::wstringstream ss;
             ss << L"Failed to load kbdlayoutmonhook.dll. Error code: 0x" << std::hex << errorCode;
-            WriteLog(ss.str());
+            WriteLog(LogLevel::Error, ss.str());
             if (g_hInstanceMutex) {
                 ReleaseMutex(g_hInstanceMutex.get());
                 g_hInstanceMutex.reset();
@@ -425,7 +425,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
             DWORD errorCode = GetLastError();
             std::wstringstream ss;
             ss << L"Failed to get function addresses from kbdlayoutmonhook.dll. Error code: 0x" << std::hex << errorCode;
-            WriteLog(ss.str());
+            WriteLog(LogLevel::Error, ss.str());
             FreeLibrary(g_hDll);
             if (g_hInstanceMutex) {
                 ReleaseMutex(g_hInstanceMutex.get());
@@ -436,7 +436,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
     // Initialize the hook module now that it's loaded
         if (!InitHookModule()) {
-            WriteLog(L"Failed to initialize hook module.");
+            WriteLog(LogLevel::Error, L"Failed to initialize hook module.");
             CleanupHookModule();
             FreeLibrary(g_hDll);
             if (g_hInstanceMutex) {
@@ -450,7 +450,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     SetDebugLoggingEnabled(g_debugEnabled.load());
 
         if (!InstallGlobalHook()) {
-            WriteLog(L"Failed to install global hook.");
+            WriteLog(LogLevel::Error, L"Failed to install global hook.");
             CleanupHookModule();
             FreeLibrary(g_hDll);
             if (g_hInstanceMutex) {
@@ -477,6 +477,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         ReleaseMutex(g_hInstanceMutex.get());
         g_hInstanceMutex.reset();
     }
-    WriteLog(L"Executable stopped.");
+    WriteLog(LogLevel::Info, L"Executable stopped.");
     return static_cast<int>(msg.wParam);
 }

--- a/source/tray_icon.cpp
+++ b/source/tray_icon.cpp
@@ -126,7 +126,7 @@ void HandleTrayCommand(HWND hwnd, WPARAM wParam) {
         }
         case ID_TRAY_TOGGLE_DEBUG:
             if (g_debugEnabled.load()) {
-                WriteLog(L"Debug logging disabled.");
+                WriteLog(LogLevel::Info, L"Debug logging disabled.");
                 g_debugEnabled.store(false);
                 if (SetDebugLoggingEnabled)
                     SetDebugLoggingEnabled(false);
@@ -134,7 +134,7 @@ void HandleTrayCommand(HWND hwnd, WPARAM wParam) {
                 g_debugEnabled.store(true);
                 if (SetDebugLoggingEnabled)
                     SetDebugLoggingEnabled(true);
-                WriteLog(L"Debug logging enabled.");
+                WriteLog(LogLevel::Info, L"Debug logging enabled.");
             }
             break;
         case ID_TRAY_RESTART:

--- a/tests/test_log.cpp
+++ b/tests/test_log.cpp
@@ -11,7 +11,7 @@ using HINSTANCE = void*;
 #endif
 
 extern HINSTANCE g_hInst;
-std::atomic<bool> g_debugEnabled{false};
+extern std::atomic<bool> g_debugEnabled;
 
 TEST_CASE("Log switches files when path changes", "[log]") {
     g_debugEnabled.store(true);


### PR DESCRIPTION
## Summary
- introduce LogLevel enum and overloads for WriteLog
- prefix log output with severity tags
- update logging calls to specify appropriate levels

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest` *(fails: filesystem error: cannot rename kbdlayoutmon.config)*

------
https://chatgpt.com/codex/tasks/task_e_68a9effdfb0883259fd85da38a2d41a2