### PR TITLE
Add configurable tray icon path and tooltip

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,8 @@ TEMP_HOTKEY_TIMEOUT=10000 # Milliseconds for temporary hotkeys to remain enabled
 LOG_PATH=path\to\logfile # Optional custom log file location
 MAX_LOG_SIZE_MB=10 # Rotate log when it exceeds this size in megabytes
 MAX_QUEUE_SIZE=1000 # Maximum number of log messages buffered before dropping oldest
+ICON_PATH=path\to\icon.ico # Optional custom tray icon
+TRAY_TOOLTIP=Some text # Custom tray icon tooltip (default "kbdlayoutmon")
 ```
 
 Lines that begin with `#` or `;` (after trimming whitespace) are treated as comments and ignored.

--- a/source/config_parser.cpp
+++ b/source/config_parser.cpp
@@ -105,6 +105,9 @@ std::map<std::wstring, std::wstring> ParseConfigLines(const std::vector<std::wst
             result[key] = ParseUnsignedOrDefault(value, 1000);
         } else if (key == L"startup" || key == L"language_hotkey" || key == L"layout_hotkey") {
             result[key] = ParseBoolOrDefault(value, false);
+        } else if (key == L"icon_path" || key == L"tray_tooltip") {
+            // String values used by the tray icon subsystem
+            result[key] = value;
         } else {
             result[key] = value;
         }

--- a/source/tray_icon.cpp
+++ b/source/tray_icon.cpp
@@ -26,8 +26,23 @@ TrayIcon::TrayIcon(HWND hwnd) {
     nid_.uID = 1;
     nid_.uFlags = NIF_ICON | NIF_MESSAGE | NIF_TIP;
     nid_.uCallbackMessage = WM_TRAYICON;
-    nid_.hIcon = LoadIcon(g_hInst, MAKEINTRESOURCE(IDI_MYAPP));
-    wcscpy_s(nid_.szTip, ARRAYSIZE(nid_.szTip), L"kbdlayoutmon");
+    // Load icon from configuration if provided, otherwise fall back to resource
+    auto iconVal = g_config.get(L"icon_path");
+    if (iconVal && !iconVal->empty()) {
+        nid_.hIcon = reinterpret_cast<HICON>(
+            LoadImageW(nullptr, iconVal->c_str(), IMAGE_ICON, 0, 0, LR_LOADFROMFILE));
+    }
+    if (!nid_.hIcon) {
+        nid_.hIcon = LoadIcon(g_hInst, MAKEINTRESOURCE(IDI_MYAPP));
+    }
+
+    // Set tray tooltip from configuration or use default name
+    auto tipVal = g_config.get(L"tray_tooltip");
+    if (tipVal && !tipVal->empty()) {
+        wcscpy_s(nid_.szTip, ARRAYSIZE(nid_.szTip), tipVal->c_str());
+    } else {
+        wcscpy_s(nid_.szTip, ARRAYSIZE(nid_.szTip), L"kbdlayoutmon");
+    }
     pShell_NotifyIcon(NIM_ADD, &nid_);
     added_ = true;
 }

--- a/tests/test_configuration.cpp
+++ b/tests/test_configuration.cpp
@@ -17,7 +17,9 @@ TEST_CASE("Valid entries are parsed", "[config]") {
         L"Temp_Hotkey_TimeOut=5000",
         L"LOG_PATH=C:/tmp/log.txt",
         L"MAX_LOG_SIZE_MB=5",
-        L"MAX_QUEUE_SIZE=2000"
+        L"MAX_QUEUE_SIZE=2000",
+        L"ICON_PATH=C:/icons/app.ico",
+        L"TRAY_TOOLTIP=Hello"
     };
     auto settings = ParseConfigLines(lines);
     REQUIRE(settings[L"debug"] == L"1");
@@ -26,6 +28,8 @@ TEST_CASE("Valid entries are parsed", "[config]") {
     REQUIRE(settings[L"log_path"] == L"C:/tmp/log.txt");
     REQUIRE(settings[L"max_log_size_mb"] == L"5");
     REQUIRE(settings[L"max_queue_size"] == L"2000");
+    REQUIRE(settings[L"icon_path"] == L"C:/icons/app.ico");
+    REQUIRE(settings[L"tray_tooltip"] == L"Hello");
 }
 
 TEST_CASE("Malformed lines are ignored", "[config]") {

--- a/tests/test_tray_icon.cpp
+++ b/tests/test_tray_icon.cpp
@@ -1,19 +1,31 @@
 #include <catch2/catch_test_macros.hpp>
 #include "../source/tray_icon.h"
+#include "../source/configuration.h"
 #include <set>
 #include <stdexcept>
 #include <atomic>
+#include <string>
 
 // Provide definitions for globals expected by tray_icon
 HINSTANCE g_hInst = nullptr;
 std::atomic<bool> g_trayIconEnabled{true};
 
+// Stub for LoadImageW used by tray icon
+static std::wstring g_loadedPath;
+HANDLE DummyLoadImage(HINSTANCE, LPCWSTR path, UINT, int, int, UINT) {
+    g_loadedPath = path ? path : L"";
+    return reinterpret_cast<HANDLE>(1);
+}
+HANDLE (*pLoadImageW)(HINSTANCE, LPCWSTR, UINT, int, int, UINT) = DummyLoadImage;
+
 // Track icon IDs added and removed
 static std::set<UINT> g_icons;
+static std::wstring g_lastTip;
 
 BOOL FakeShellNotifyIcon(DWORD msg, PNOTIFYICONDATA data) {
     if (msg == NIM_ADD) {
         g_icons.insert(data->uID);
+        g_lastTip = data->szTip;
     } else if (msg == NIM_DELETE) {
         g_icons.erase(data->uID);
     }
@@ -30,4 +42,16 @@ TEST_CASE("TrayIcon removes icon on destruction during exception") {
         // swallow
     }
     REQUIRE(g_icons.empty());
+}
+
+TEST_CASE("TrayIcon uses configured icon and tooltip") {
+    g_icons.clear();
+    g_lastTip.clear();
+    g_loadedPath.clear();
+    pShell_NotifyIcon = FakeShellNotifyIcon;
+    g_config.set(L"icon_path", L"custom.ico");
+    g_config.set(L"tray_tooltip", L"CustomTip");
+    TrayIcon icon(reinterpret_cast<HWND>(1));
+    REQUIRE(g_loadedPath == L"custom.ico");
+    REQUIRE(g_lastTip == L"CustomTip");
 }

--- a/tests/windows.h
+++ b/tests/windows.h
@@ -116,6 +116,8 @@ struct FILE_NOTIFY_INFORMATION {
 #define NIF_TIP 0x00000004
 #define NIM_ADD 0x00000000
 #define NIM_DELETE 0x00000002
+#define IMAGE_ICON 1
+#define LR_LOADFROMFILE 0x00000010
 #ifndef ARRAYSIZE
 #define ARRAYSIZE(A) (sizeof(A) / sizeof((A)[0]))
 #endif
@@ -150,6 +152,7 @@ extern "C" {
     extern BOOL (*pGetOverlappedResult)(HANDLE, OVERLAPPED*, DWORD*, BOOL);
     extern DWORD (*pWaitForMultipleObjects)(DWORD, const HANDLE*, BOOL, DWORD);
     extern DWORD (*pGetModuleFileNameW)(HINSTANCE, wchar_t*, DWORD);
+    extern HANDLE (*pLoadImageW)(HINSTANCE, LPCWSTR, UINT, int, int, UINT);
 
     ATOM RegisterClass(const WNDCLASS*);
     HWND CreateWindowEx(DWORD, LPCWSTR, LPCWSTR, DWORD, int, int, int, int, HWND, HANDLE, HINSTANCE, LPVOID);
@@ -197,6 +200,7 @@ inline BOOL CancelIoEx(HANDLE a, OVERLAPPED* b) { return pCancelIoEx(a,b); }
 inline BOOL GetOverlappedResult(HANDLE a, OVERLAPPED* b, DWORD* c, BOOL d) { return pGetOverlappedResult(a,b,c,d); }
 inline DWORD WaitForMultipleObjects(DWORD a, const HANDLE* b, BOOL c, DWORD d) { return pWaitForMultipleObjects(a,b,c,d); }
 inline DWORD GetModuleFileNameW(HINSTANCE inst, wchar_t* buffer, DWORD size) { return pGetModuleFileNameW(inst, buffer, size); }
+inline HANDLE LoadImageW(HINSTANCE a, LPCWSTR b, UINT c, int d, int e, UINT f) { return pLoadImageW(a,b,c,d,e,f); }
 inline void CloseHandle(HANDLE) {}
 inline BOOL WriteFile(HANDLE, const void*, DWORD, DWORD*, void*) { return TRUE; }
 inline LONG RegOpenKeyEx(HKEY, LPCWSTR, DWORD, DWORD, HKEY*) { return ERROR_SUCCESS; }


### PR DESCRIPTION
## Summary
- add `icon_path` and `tray_tooltip` to configuration parsing
- load tray icon from custom path and apply tooltip text
- document new options and test tray icon config usage

## Testing
- `scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a9f11dee78832589e5263b3a1e702a