### PR TITLE
Add POSIX config watcher and platform-aware build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,26 +70,38 @@ endif()
 # Unit tests
 find_package(Catch2 3 REQUIRED)
 
-add_executable(run_tests
+set(TEST_SOURCES
     tests/test_configuration.cpp
     tests/test_log.cpp
-    tests/test_utils.cpp
     tests/bench_pipe.cpp
-    tests/test_config_watcher.cpp
-    tests/test_worker_thread.cpp
-    tests/test_hotkey_registry.cpp
+)
+
+set(RUN_SOURCES
     source/log.cpp
     source/configuration.cpp
     source/config_parser.cpp
-    source/config_watcher.cpp
-    source/hotkey_registry.cpp
-    source/kbdlayoutmonhook.cpp
 )
 
+if(WIN32)
+    list(APPEND TEST_SOURCES
+        tests/test_utils.cpp
+        tests/test_config_watcher.cpp
+        tests/test_worker_thread.cpp
+        tests/test_hotkey_registry.cpp
+    )
+    list(APPEND RUN_SOURCES
+        source/config_watcher.cpp
+        source/hotkey_registry.cpp
+        source/kbdlayoutmonhook.cpp
+    )
+else()
+    list(APPEND RUN_SOURCES source/config_watcher_posix.cpp tests/stubs.cpp)
+endif()
+
+add_executable(run_tests ${TEST_SOURCES} ${RUN_SOURCES})
 target_include_directories(run_tests PRIVATE tests source)
 target_link_libraries(run_tests PRIVATE Catch2::Catch2WithMain)
 target_compile_definitions(run_tests PRIVATE UNIT_TEST)
 
 enable_testing()
 add_test(NAME run_tests COMMAND run_tests)
-

--- a/source/config_watcher.cpp
+++ b/source/config_watcher.cpp
@@ -1,3 +1,4 @@
+#ifdef _WIN32
 #include "config_watcher.h"
 
 #include <string>
@@ -134,4 +135,4 @@ void ConfigWatcher::threadProc(ConfigWatcher* self) {
         }
     }
 }
-
+#endif

--- a/source/config_watcher.h
+++ b/source/config_watcher.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#ifdef _WIN32
 #include <windows.h>
 #include <thread>
 #include "handle_guard.h"
@@ -27,4 +28,6 @@ private:
     std::thread m_thread;   ///< Background thread.
     HandleGuard m_stopEvent; ///< Event used to signal thread shutdown.
 };
-
+#else
+#include "config_watcher_posix.h"
+#endif

--- a/source/config_watcher_posix.cpp
+++ b/source/config_watcher_posix.cpp
@@ -1,0 +1,71 @@
+#include "config_watcher_posix.h"
+
+#ifndef _WIN32
+#include "configuration.h"
+#include "log.h"
+
+#include <sys/inotify.h>
+#include <unistd.h>
+#include <filesystem>
+#include <vector>
+#include <chrono>
+#include <string>
+#include <limits.h>
+
+void ApplyConfig(HWND);
+
+ConfigWatcher::ConfigWatcher(HWND hwnd) : m_hwnd(hwnd) {
+    m_thread = std::thread(&ConfigWatcher::threadProc, this);
+}
+
+ConfigWatcher::~ConfigWatcher() {
+    m_stop = true;
+    if (m_thread.joinable())
+        m_thread.join();
+    if (m_wd >= 0)
+        inotify_rm_watch(m_fd, m_wd);
+    if (m_fd >= 0)
+        close(m_fd);
+}
+
+void ConfigWatcher::threadProc() {
+    namespace fs = std::filesystem;
+    std::wstring cfgPathW = g_config.getLastPath();
+    std::string cfgPath(cfgPathW.begin(), cfgPathW.end());
+    if (cfgPath.empty())
+        cfgPath = "kbdlayoutmon.config";
+    std::string dir = fs::path(cfgPath).parent_path().string();
+    if (dir.empty())
+        dir = ".";
+
+    m_fd = inotify_init1(0);
+    if (m_fd < 0)
+        return;
+
+    m_wd = inotify_add_watch(m_fd, dir.c_str(), IN_CLOSE_WRITE | IN_MOVED_TO | IN_MOVED_FROM);
+    if (m_wd < 0)
+        return;
+
+    std::vector<char> buffer(sizeof(struct inotify_event) + NAME_MAX + 1);
+    while (!m_stop) {
+        ssize_t len = read(m_fd, buffer.data(), buffer.size());
+        if (len <= 0) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            continue;
+        }
+        for (char* ptr = buffer.data(); ptr < buffer.data() + len; ) {
+            auto* ev = reinterpret_cast<struct inotify_event*>(ptr);
+            if (ev->mask & (IN_CLOSE_WRITE | IN_MOVED_TO | IN_MOVED_FROM)) {
+                g_config.load();
+                ApplyConfig(m_hwnd);
+                WriteLog(LogLevel::Info, L"Configuration reloaded.");
+            }
+            ptr += sizeof(struct inotify_event) + ev->len;
+        }
+    }
+}
+
+// Stub ApplyConfig for non-Windows builds
+void ApplyConfig(HWND) {}
+
+#endif // !_WIN32

--- a/source/config_watcher_posix.h
+++ b/source/config_watcher_posix.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#ifndef _WIN32
+#include <thread>
+#include <atomic>
+
+// Dummy HWND type for non-Windows builds
+using HWND = void*;
+
+class ConfigWatcher {
+public:
+    explicit ConfigWatcher(HWND hwnd);
+    ~ConfigWatcher();
+
+    ConfigWatcher(const ConfigWatcher&) = delete;
+    ConfigWatcher& operator=(const ConfigWatcher&) = delete;
+
+private:
+    void threadProc();
+
+    HWND m_hwnd;
+    std::thread m_thread;
+    int m_fd{-1};
+    int m_wd{-1};
+    std::atomic<bool> m_stop{false};
+};
+
+#endif // !_WIN32

--- a/tests/stubs.cpp
+++ b/tests/stubs.cpp
@@ -1,0 +1,3 @@
+#include <atomic>
+
+std::atomic<bool> g_debugEnabled{false};


### PR DESCRIPTION
## Summary
- guard existing Windows configuration watcher with `_WIN32`
- add inotify-based `ConfigWatcher` for POSIX platforms
- update CMake to select watcher and tests per platform

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68aa14b8af788325ba6b12a9480fd77f