### PR TITLE
Add status CLI option to display startup and hotkey states

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,7 @@ configuration file. Use `--help` to display a summary at runtime:
 --enable-language-hotkey  Enable the Windows "Language" hotkey
 --disable-layout-hotkey   Disable the Windows "Layout" hotkey
 --version                 Print the application version and exit
+--status                  Print startup and hotkey states and exit
 --help                    Show this help text
 ```
 
@@ -73,6 +74,15 @@ Disable startup launch and the layout hotkey:
 
 ```bash
 kbdlayoutmon --disable-startup --disable-layout-hotkey
+```
+
+Display current startup and hotkey status:
+
+```bash
+kbdlayoutmon --status
+Startup: disabled
+Language hotkey: enabled
+Layout hotkey: disabled
 ```
 
 ## Build


### PR DESCRIPTION
## Summary
- add `--status` flag to report startup and hotkey states
- document status command and example output

## Testing
- `scripts/run_tests.sh` *(fails: HINSTANCE does not name a type)*

------
https://chatgpt.com/codex/tasks/task_e_68aa17d18c308325a0de7912ec47a2e4