### PR TITLE
Add CLI flags to toggle language and layout hotkeys

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,8 @@ configuration file. Use `--help` to display a summary at runtime:
 --enable-startup          Add the application to user startup
 --disable-startup         Remove the application from user startup
 --enable-language-hotkey  Enable the Windows "Language" hotkey
+--disable-language-hotkey Disable the Windows "Language" hotkey
+--enable-layout-hotkey    Enable the Windows "Layout" hotkey
 --disable-layout-hotkey   Disable the Windows "Layout" hotkey
 --version                 Print the application version and exit
 --status                  Print startup and hotkey states and exit
@@ -74,6 +76,18 @@ Disable startup launch and the layout hotkey:
 
 ```bash
 kbdlayoutmon --disable-startup --disable-layout-hotkey
+```
+
+Enable the layout hotkey:
+
+```bash
+kbdlayoutmon --enable-layout-hotkey
+```
+
+Disable the language hotkey:
+
+```bash
+kbdlayoutmon --disable-language-hotkey
 ```
 
 Display current startup and hotkey status:

--- a/source/kbdlayoutmon.cpp
+++ b/source/kbdlayoutmon.cpp
@@ -97,6 +97,8 @@ std::wstring GetUsageString() {
         L"  --enable-startup           Add application to user startup\n"
         L"  --disable-startup          Remove application from user startup\n"
         L"  --enable-language-hotkey   Enable the Windows \"Language\" hotkey\n"
+        L"  --disable-language-hotkey  Disable the Windows \"Language\" hotkey\n"
+        L"  --enable-layout-hotkey     Enable the Windows \"Layout\" hotkey\n"
         L"  --disable-layout-hotkey    Disable the Windows \"Layout\" hotkey\n"
         L"  --version    Print the application version and exit\n"
         L"  --status     Print startup and hotkey states and exit\n"
@@ -259,6 +261,10 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
                 RemoveFromStartup();
             } else if (wcscmp(argv[i], L"--enable-language-hotkey") == 0) {
                 ToggleLanguageHotKey(nullptr, true, true);
+            } else if (wcscmp(argv[i], L"--disable-language-hotkey") == 0) {
+                ToggleLanguageHotKey(nullptr, true, false);
+            } else if (wcscmp(argv[i], L"--enable-layout-hotkey") == 0) {
+                ToggleLayoutHotKey(nullptr, true, true);
             } else if (wcscmp(argv[i], L"--disable-layout-hotkey") == 0) {
                 ToggleLayoutHotKey(nullptr, true, false);
             } else if (wcscmp(argv[i], L"--cli") == 0 || wcscmp(argv[i], L"--cli-mode") == 0) {


### PR DESCRIPTION
## Summary
- add `--disable-language-hotkey` and `--enable-layout-hotkey` options
- document new hotkey flags
- test language/layout hotkey toggling

## Testing
- `g++ -std=c++17 -DUNIT_TEST -I tests -I resources tests/test_hotkey_registry.cpp tests/stubs.cpp source/hotkey_registry.cpp source/configuration.cpp source/log.cpp source/config_parser.cpp -o tests/run_hotkey_tests -lCatch2Main -lCatch2 -pthread && tests/run_hotkey_tests`

------
https://chatgpt.com/codex/tasks/task_e_68aa2fc19fac832584e995c2732c7eb0