### PR TITLE
Handle hotkey CLI flags for language and layout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(kbdlayoutmon
     source/log.cpp
     source/tray_icon.cpp
     source/hotkey_registry.cpp
+    source/hotkey_cli.cpp
     resources/res-icon.rc
     resources/res-versioninfo.rc
 )
@@ -92,6 +93,7 @@ if(WIN32)
     list(APPEND RUN_SOURCES
         source/config_watcher.cpp
         source/hotkey_registry.cpp
+        source/hotkey_cli.cpp
         source/kbdlayoutmonhook.cpp
     )
 else()

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,10 @@ configuration file. Use `--help` to display a summary at runtime:
 --help                    Show this help text
 ```
 
+The `--disable-language-hotkey` and `--enable-layout-hotkey` flags let you
+explicitly turn the Windows *Language* or *Layout* hotkeys off or on from the
+command line.
+
 ### Examples
 
 Enable startup launch and the language hotkey:

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -9,8 +9,10 @@ fi
 
 g++ -std=c++17 -DUNIT_TEST -I tests -I resources \
     tests/test_configuration.cpp tests/test_log.cpp tests/test_utils.cpp tests/test_timer_guard.cpp \
-    tests/test_tray_icon.cpp tests/test_tray_icon_integration.cpp tests/test_tray_icon_update.cpp tests/stubs.cpp \
+    tests/test_tray_icon.cpp tests/test_tray_icon_integration.cpp tests/test_tray_icon_update.cpp \
+    tests/test_hotkey_registry.cpp tests/stubs.cpp \
     source/configuration.cpp source/log.cpp source/config_parser.cpp source/tray_icon.cpp \
+    source/hotkey_registry.cpp source/hotkey_cli.cpp source/config_watcher.cpp \
     -o tests/run_tests \
     -lCatch2Main -lCatch2 -pthread
 ./tests/run_tests

--- a/source/hotkey_cli.cpp
+++ b/source/hotkey_cli.cpp
@@ -1,0 +1,22 @@
+#include "hotkey_cli.h"
+#include "hotkey_registry.h"
+
+bool HandleHotkeyFlag(const wchar_t* flag) {
+    if (wcscmp(flag, L"--enable-language-hotkey") == 0) {
+        ToggleLanguageHotKey(nullptr, true, true);
+        return true;
+    }
+    if (wcscmp(flag, L"--disable-language-hotkey") == 0) {
+        ToggleLanguageHotKey(nullptr, true, false);
+        return true;
+    }
+    if (wcscmp(flag, L"--enable-layout-hotkey") == 0) {
+        ToggleLayoutHotKey(nullptr, true, true);
+        return true;
+    }
+    if (wcscmp(flag, L"--disable-layout-hotkey") == 0) {
+        ToggleLayoutHotKey(nullptr, true, false);
+        return true;
+    }
+    return false;
+}

--- a/source/hotkey_cli.h
+++ b/source/hotkey_cli.h
@@ -1,0 +1,4 @@
+#pragma once
+#include <cwchar>
+
+bool HandleHotkeyFlag(const wchar_t* flag);

--- a/source/kbdlayoutmon.cpp
+++ b/source/kbdlayoutmon.cpp
@@ -17,6 +17,7 @@
 #include "config_watcher.h"
 #include "tray_icon.h"
 #include "hotkey_registry.h"
+#include "hotkey_cli.h"
 
 // Forward declarations
 void ApplyConfig(HWND hwnd);
@@ -104,6 +105,8 @@ std::wstring GetUsageString() {
         L"  --status     Print startup and hotkey states and exit\n"
         L"  --help       Show this help message and exit";
 }
+
+
 
 
 
@@ -274,14 +277,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
                 AddToStartup();
             } else if (wcscmp(argv[i], L"--disable-startup") == 0) {
                 RemoveFromStartup();
-            } else if (wcscmp(argv[i], L"--enable-language-hotkey") == 0) {
-                ToggleLanguageHotKey(nullptr, true, true);
-            } else if (wcscmp(argv[i], L"--disable-language-hotkey") == 0) {
-                ToggleLanguageHotKey(nullptr, true, false);
-            } else if (wcscmp(argv[i], L"--enable-layout-hotkey") == 0) {
-                ToggleLayoutHotKey(nullptr, true, true);
-            } else if (wcscmp(argv[i], L"--disable-layout-hotkey") == 0) {
-                ToggleLayoutHotKey(nullptr, true, false);
+            } else if (HandleHotkeyFlag(argv[i])) {
+                // Hotkey flag processed
             } else if (wcscmp(argv[i], L"--cli") == 0 || wcscmp(argv[i], L"--cli-mode") == 0) {
                 g_cliMode = true;
                 g_trayIconEnabled.store(false);

--- a/tests/test_hotkey_registry.cpp
+++ b/tests/test_hotkey_registry.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include "../source/hotkey_registry.h"
 #include "../source/configuration.h"
+#include "../source/hotkey_cli.h"
 #include <filesystem>
 #include <fstream>
 #include <chrono>
@@ -9,8 +10,8 @@
 
 LONG g_RegSetValueExResult = ERROR_SUCCESS;
 extern std::atomic<bool> g_debugEnabled;
-UINT (*pSetTimer)(HWND, UINT, UINT, TIMERPROC) = [](HWND, UINT, UINT, TIMERPROC) -> UINT { return 1; };
-BOOL (*pKillTimer)(HWND, UINT) = [](HWND, UINT) -> BOOL { return TRUE; };
+extern UINT (*pSetTimer)(HWND, UINT, UINT, TIMERPROC);
+extern BOOL (*pKillTimer)(HWND, UINT);
 std::atomic<bool> g_languageHotKeyEnabled{false};
 std::atomic<bool> g_layoutHotKeyEnabled{false};
 SetLanguageHotKeyEnabledFunc SetLanguageHotKeyEnabled = nullptr;
@@ -92,6 +93,20 @@ TEST_CASE("EnableLayoutHotKey sets flag to enabled") {
     ToggleLayoutHotKey(nullptr, true, false);
     REQUIRE_FALSE(g_layoutHotKeyEnabled.load());
     ToggleLayoutHotKey(nullptr, true, true);
+    REQUIRE(g_layoutHotKeyEnabled.load());
+}
+
+TEST_CASE("Command line flag disables Language hotkey") {
+    g_RegSetValueExResult = ERROR_SUCCESS;
+    g_languageHotKeyEnabled.store(true);
+    REQUIRE(HandleHotkeyFlag(L"--disable-language-hotkey"));
+    REQUIRE_FALSE(g_languageHotKeyEnabled.load());
+}
+
+TEST_CASE("Command line flag enables Layout hotkey") {
+    g_RegSetValueExResult = ERROR_SUCCESS;
+    g_layoutHotKeyEnabled.store(false);
+    REQUIRE(HandleHotkeyFlag(L"--enable-layout-hotkey"));
     REQUIRE(g_layoutHotKeyEnabled.load());
 }
 


### PR DESCRIPTION
## Summary
- add `HandleHotkeyFlag` helper and wire it into command-line parser
- document `--disable-language-hotkey` and `--enable-layout-hotkey`
- test CLI flags toggle hotkey state

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68aa34939f548325b20303674ebe38f2