### PR TITLE
Warn on unrecognized CLI flags

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -6,6 +6,7 @@ cxx.std = 17
 # Build the main executable
 exe{kbdlayoutmon}: \
   source/kbdlayoutmon.cpp \
+  source/cli_utils.cpp \
   source/configuration.cpp \
   source/config_parser.cpp \
   source/log.cpp \
@@ -24,9 +25,11 @@ exe{run_tests}: \
   tests/test_configuration.cpp \
   tests/test_log.cpp \
   tests/test_utils.cpp \
+  tests/test_unknown_option.cpp \
   source/log.cpp \
   source/configuration.cpp \
-  source/config_parser.cpp
+  source/config_parser.cpp \
+  source/cli_utils.cpp
 
 # Register test target
 test{run_tests}

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -10,9 +10,9 @@ fi
 g++ -std=c++17 -DUNIT_TEST -I tests -I resources \
     tests/test_configuration.cpp tests/test_log.cpp tests/test_utils.cpp tests/test_timer_guard.cpp \
     tests/test_tray_icon.cpp tests/test_tray_icon_integration.cpp tests/test_tray_icon_update.cpp \
-    tests/test_hotkey_registry.cpp tests/stubs.cpp \
+    tests/test_hotkey_registry.cpp tests/test_unknown_option.cpp tests/stubs.cpp \
     source/configuration.cpp source/log.cpp source/config_parser.cpp source/tray_icon.cpp \
-    source/hotkey_registry.cpp source/hotkey_cli.cpp source/config_watcher.cpp \
+    source/hotkey_registry.cpp source/hotkey_cli.cpp source/config_watcher.cpp source/cli_utils.cpp \
     -o tests/run_tests \
     -lCatch2Main -lCatch2 -pthread
 ./tests/run_tests

--- a/source/cli_utils.cpp
+++ b/source/cli_utils.cpp
@@ -1,0 +1,58 @@
+#include "cli_utils.h"
+#include "log.h"
+#include <sstream>
+#include <cstdio>
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+extern bool g_cliMode;
+
+std::wstring GetUsageString() {
+    return
+        L"Usage: kbdlayoutmon [options]\n\n"
+        L"Options:\n"
+        L"  --config <path>  Load configuration from the specified file\n"
+        L"  --no-tray    Run without the system tray icon\n"
+        L"  --debug      Enable debug logging\n"
+        L"  --verbose    Increase logging verbosity\n"
+        L"  --cli        Run in CLI mode without GUI/tray icon\n"
+        L"  --tray-icon <0|1>        Override tray icon setting\n"
+        L"  --temp-hotkey-timeout <ms>  Override temporary hotkey timeout\n"
+        L"  --log-path <path>          Override log file location\n"
+        L"  --max-log-size-mb <num>    Override max log size\n"
+        L"  --max-queue-size <num>     Override log queue length\n"
+        L"  --enable-startup           Add application to user startup\n"
+        L"  --disable-startup          Remove application from user startup\n"
+        L"  --enable-language-hotkey   Enable the Windows \"Language\" hotkey\n"
+        L"  --disable-language-hotkey  Disable the Windows \"Language\" hotkey\n"
+        L"  --enable-layout-hotkey     Enable the Windows \"Layout\" hotkey\n"
+        L"  --disable-layout-hotkey    Disable the Windows \"Layout\" hotkey\n"
+        L"  --version    Print the application version and exit\n"
+        L"  --status     Print startup and hotkey states and exit\n"
+        L"  --help       Show this help message and exit";
+}
+
+void WarnUnrecognizedOption(const wchar_t* option) {
+    std::wstringstream ss;
+    ss << L"Unrecognized option: " << option;
+    WriteLog(LogLevel::Error, ss.str());
+    ss << L"\n\n" << GetUsageString();
+#ifdef _WIN32
+    if (g_cliMode || AttachConsole(ATTACH_PARENT_PROCESS)) {
+        FILE* fp = _wfopen(L"CONOUT$", L"w");
+        if (fp) {
+            fwprintf(fp, L"%s\n", ss.str().c_str());
+            fclose(fp);
+        }
+        if (!g_cliMode)
+            FreeConsole();
+    } else {
+        MessageBox(NULL, ss.str().c_str(), L"Input Method Monitor", MB_OK | MB_ICONEXCLAMATION);
+    }
+#else
+    if (g_cliMode) {
+        fwprintf(stdout, L"%s\n", ss.str().c_str());
+    }
+#endif
+}

--- a/source/cli_utils.h
+++ b/source/cli_utils.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <string>
+
+// Return a short usage string describing supported options.
+std::wstring GetUsageString();
+
+// Log and display a message for unrecognized command line options.
+void WarnUnrecognizedOption(const wchar_t* option);

--- a/source/kbdlayoutmon.cpp
+++ b/source/kbdlayoutmon.cpp
@@ -18,6 +18,7 @@
 #include "tray_icon.h"
 #include "hotkey_registry.h"
 #include "hotkey_cli.h"
+#include "cli_utils.h"
 
 // Forward declarations
 void ApplyConfig(HWND hwnd);
@@ -79,36 +80,6 @@ std::wstring GetVersionString() {
              LOWORD(info->dwFileVersionLS));
     return ver;
 }
-
-// Return a short usage string describing supported options
-std::wstring GetUsageString() {
-    return
-        L"Usage: kbdlayoutmon [options]\n\n"
-        L"Options:\n"
-        L"  --config <path>  Load configuration from the specified file\n"
-        L"  --no-tray    Run without the system tray icon\n"
-        L"  --debug      Enable debug logging\n"
-        L"  --verbose    Increase logging verbosity\n"
-        L"  --cli        Run in CLI mode without GUI/tray icon\n"
-        L"  --tray-icon <0|1>        Override tray icon setting\n"
-        L"  --temp-hotkey-timeout <ms>  Override temporary hotkey timeout\n"
-        L"  --log-path <path>          Override log file location\n"
-        L"  --max-log-size-mb <num>    Override max log size\n"
-        L"  --max-queue-size <num>     Override log queue length\n"
-        L"  --enable-startup           Add application to user startup\n"
-        L"  --disable-startup          Remove application from user startup\n"
-        L"  --enable-language-hotkey   Enable the Windows \"Language\" hotkey\n"
-        L"  --disable-language-hotkey  Disable the Windows \"Language\" hotkey\n"
-        L"  --enable-layout-hotkey     Enable the Windows \"Layout\" hotkey\n"
-        L"  --disable-layout-hotkey    Disable the Windows \"Layout\" hotkey\n"
-        L"  --version    Print the application version and exit\n"
-        L"  --status     Print startup and hotkey states and exit\n"
-        L"  --help       Show this help message and exit";
-}
-
-
-
-
 
 // Apply configuration values to runtime settings
 void ApplyConfig(HWND hwnd) {
@@ -360,6 +331,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
                     g_hInstanceMutex.reset();
                 }
                 return 0;
+            } else {
+                WarnUnrecognizedOption(argv[i]);
+                LocalFree(argv);
+                if (g_hInstanceMutex) {
+                    ReleaseMutex(g_hInstanceMutex.get());
+                    g_hInstanceMutex.reset();
+                }
+                return 1;
             }
         }
         ApplyConfig(NULL);

--- a/tests/stubs.cpp
+++ b/tests/stubs.cpp
@@ -1,3 +1,4 @@
 #include <atomic>
 
 std::atomic<bool> g_debugEnabled{false};
+bool g_cliMode = false;

--- a/tests/test_unknown_option.cpp
+++ b/tests/test_unknown_option.cpp
@@ -1,0 +1,33 @@
+#include <catch2/catch_test_macros.hpp>
+#include <filesystem>
+#include <fstream>
+#include <chrono>
+#include <thread>
+#include <atomic>
+#include "../source/cli_utils.h"
+#include "../source/configuration.h"
+
+extern std::atomic<bool> g_debugEnabled;
+extern bool g_cliMode;
+
+TEST_CASE("WarnUnrecognizedOption logs error") {
+    using namespace std::chrono_literals;
+    namespace fs = std::filesystem;
+
+    g_debugEnabled.store(true);
+    g_cliMode = true;
+
+    fs::path logPath = fs::temp_directory_path() / "unknown_option.log";
+    g_config.set(L"log_path", logPath.wstring());
+
+    WarnUnrecognizedOption(L"--bogus-flag");
+    std::this_thread::sleep_for(200ms);
+
+    std::wifstream file(logPath);
+    std::wstring content((std::istreambuf_iterator<wchar_t>(file)),
+                         std::istreambuf_iterator<wchar_t>());
+    REQUIRE(content.find(L"Unrecognized option: --bogus-flag") != std::wstring::npos);
+
+    g_config.set(L"log_path", L"");
+    fs::remove(logPath);
+}


### PR DESCRIPTION
## Summary
- log and report unrecognized command line options
- exit with error when unknown flags are provided
- test that unknown options trigger a warning

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68aa4685ff10832588912ea8b09b83ea