### PR TITLE
Add POSIX config watcher test

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -10,9 +10,9 @@ fi
 g++ -std=c++17 -DUNIT_TEST -I tests -I resources \
     tests/test_configuration.cpp tests/test_log.cpp tests/test_utils.cpp tests/test_timer_guard.cpp \
     tests/test_tray_icon.cpp tests/test_tray_icon_integration.cpp tests/test_tray_icon_update.cpp \
-    tests/test_hotkey_registry.cpp tests/test_unknown_option.cpp tests/stubs.cpp \
+    tests/test_hotkey_registry.cpp tests/test_unknown_option.cpp tests/test_config_watcher_posix.cpp tests/stubs.cpp \
     source/configuration.cpp source/log.cpp source/config_parser.cpp source/tray_icon.cpp \
-    source/hotkey_registry.cpp source/hotkey_cli.cpp source/config_watcher.cpp source/cli_utils.cpp \
+    source/hotkey_registry.cpp source/hotkey_cli.cpp source/config_watcher.cpp source/config_watcher_posix.cpp source/cli_utils.cpp \
     source/app_state.cpp \
     -o tests/run_tests \
     -lCatch2Main -lCatch2 -pthread

--- a/tests/test_config_watcher_posix.cpp
+++ b/tests/test_config_watcher_posix.cpp
@@ -1,0 +1,85 @@
+#include <catch2/catch_test_macros.hpp>
+#ifndef _WIN32
+#include <filesystem>
+#include <fstream>
+#include <thread>
+#include <chrono>
+
+#include "../source/config_watcher_posix.h"
+#include "../source/configuration.h"
+#include "../source/app_state.h"
+
+extern void (*g_testApplyConfig)(HWND);
+
+namespace {
+int applyCalls = 0;
+void RecordApply(HWND) { ++applyCalls; }
+}
+
+TEST_CASE("ConfigWatcher reloads on file changes", "[config_watcher][posix]") {
+    using namespace std::chrono_literals;
+    namespace fs = std::filesystem;
+
+    bool prevDebug = GetAppState().debugEnabled.load();
+    GetAppState().debugEnabled.store(true);
+
+    fs::path dir = fs::temp_directory_path() / "immon_cfgwatch_posix";
+    fs::create_directories(dir);
+    fs::path cfg = dir / "kbdlayoutmon.config";
+    fs::path logPath = dir / "watch.log";
+
+    {
+        std::wofstream f(cfg);
+        f << L"log_path=" << logPath.wstring() << L"\n";
+        f << L"key=value\n";
+    }
+
+    g_config.load(cfg.wstring());
+
+    applyCalls = 0;
+    g_testApplyConfig = RecordApply;
+
+    {
+        ConfigWatcher watcher(nullptr);
+        std::this_thread::sleep_for(100ms);
+
+        {
+            std::wofstream f(cfg);
+            f << L"log_path=" << logPath.wstring() << L"\n";
+            f << L"key=updated\n";
+        }
+        std::this_thread::sleep_for(100ms);
+
+        fs::path tmp = dir / "kbdlayoutmon.tmp";
+        fs::rename(cfg, tmp);
+        fs::rename(tmp, cfg);
+        std::this_thread::sleep_for(200ms);
+
+        // Trigger a final write but do not wait so the watcher thread sees the
+        // event after destruction and can exit promptly.
+        {
+            std::wofstream f(cfg);
+            f << L"log_path=" << logPath.wstring() << L"\n";
+            f << L"key=final\n";
+        }
+    }
+
+    g_testApplyConfig = nullptr;
+    std::this_thread::sleep_for(200ms);
+
+    REQUIRE(applyCalls >= 2);
+
+    std::wifstream logFile(logPath);
+    std::wstring line;
+    size_t count = 0;
+    while (std::getline(logFile, line)) {
+        if (line.find(L"Configuration reloaded.") != std::wstring::npos)
+            ++count;
+    }
+    REQUIRE(count >= 2);
+
+    fs::remove_all(dir);
+    g_config.set(L"log_path", L"");
+    GetAppState().debugEnabled.store(prevDebug);
+}
+#endif


### PR DESCRIPTION
## Summary
- expose test hook and clean shutdown for POSIX ConfigWatcher
- add POSIX config watcher test covering file write and rename reloads
- include test in run_tests.sh

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68aba96a23d08325b19b728229cc5f1d